### PR TITLE
Changed the logic when duffy can't reach a node through ssh 

### DIFF
--- a/duffy/models/nodes.py
+++ b/duffy/models/nodes.py
@@ -69,7 +69,7 @@ class Host(Duffyv1Model):
             sftp = ssh.open_sftp()
             file_handle = sftp.file('/root/.ssh/authorized_keys', mode='a', bufsize=-1)
         except Exception as e:
-            self.state = 'Ready'
+            self.state = 'Active'
             self.save()
             return False
 


### PR DESCRIPTION
The following simple patch should fix #5 and so not block in loop when trying to contextualize the unreachable node