### PR TITLE
Pin the version of marshmallow to 3.0.0b6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setuptools.setup(
         'flask-migrate',
         'flask-marshmallow',
         'marshmallow-sqlalchemy',
+        'marshmallow==3.0.0b6',
         'paramiko',
     ],
 


### PR DESCRIPTION
We use `dump_to` in our schemas, they're deprecating this keyword in
favor of another one:
https://github.com/marshmallow-code/marshmallow/issues/717

This keeps duffy deployable for now.