### PR TITLE
Support excluding group of machines in queries

### DIFF
--- a/duffy/data.py
+++ b/duffy/data.py
@@ -58,6 +58,32 @@ def _populate_test_data():
                    pool=1,
                    console_port=123)
 
+    n1crusty = Host(hostname='n1.crusty',
+                   ip='127.0.0.5',
+                   chassis='crusty',
+                   used_count=99,
+                   state='Ready',
+                   comment='-',
+                   distro=None,
+                   rel=None,
+                   ver=7,
+                   arch='x86_64',
+                   pool=1,
+                   console_port=123)
+
+    n2crusty = Host(hostname='n2.crusty',
+                   ip='127.0.0.5',
+                   chassis='crusty',
+                   used_count=99,
+                   state='Ready',
+                   comment='-',
+                   distro=None,
+                   rel=None,
+                   ver=7,
+                   arch='x86_64',
+                   pool=1,
+                   console_port=123)
+
     n1p8h1 = Host(hostname='n1.p8h1',
                   ip='127.0.0.6',
                   chassis='p8h1',
@@ -96,6 +122,8 @@ def _populate_test_data():
     db.session.add(n2hufty)
     db.session.add(n3hufty)
     db.session.add(n4hufty)
+    db.session.add(n1crusty)
+    db.session.add(n2crusty)
     db.session.add(n1p8h1)
     db.session.add(n2p8h1)
     db.session.add(testproject)

--- a/tests/test_v1_api.py
+++ b/tests/test_v1_api.py
@@ -99,6 +99,28 @@ class DuffyV1ApiTests(unittest.TestCase):
                 assert h.state == 'Deployed'
                 assert h.flavor == 'medium'
 
+    def test_api_returns_host_without_excluded_hostname(self):
+        for hname in [".hufty", ".crusty", "n2.crusty"]:
+            r1 = self.client.get('/Node/get?key=asdf-1234&exclude_host=%{}'.format(hname))
+            data = json.loads(r1.data)
+
+            for hostname in data['hosts']:
+                with self.testapp.app_context():
+                    h = Host.query.filter(Host.hostname == hostname).one()
+                    assert h.ver == '7'
+                    assert not hostname.endswith(hname)
+
+    def test_api_returns_host_without_multiple_excluded_hostnames(self):
+        r1 = self.client.get('/Node/get?key=asdf-1234&exclude_host=%.hufty,n1.crusty')
+        data = json.loads(r1.data)
+
+        for hostname in data['hosts']:
+            with self.testapp.app_context():
+                h = Host.query.filter(Host.hostname == hostname).one()
+                assert h.ver == '7'
+                assert not hostname.endswith('.hufty')
+                assert hostname != 'n1.crusty'
+
     def test_api_returns_multiple_hosts(self):
         r = self.client.get('/Node/get?key=asdf-1234&count=2')
         data = json.loads(r.data)


### PR DESCRIPTION
Hello!

First of all, this is more like RFC than an actual PR, since my experience with SQLAlchemy and flask is minimal. However, I'd really welcome a mechanism for including/excluding certain hosts from Duffy `/Node/get` queries.

A bit of background: one of our systemd jobs in CentOS CI uses nested KVM, which in combination with one systemd-nspawn test causes CPU soft/hard lockups on all *.duffy nodes (with Intel Xeon CPUs), other nodes (with AMD Opteron) don't have this issue.. This took an obscene amount of time to find out, and all my attempts to workaround this were thwarted (temporarily disabling Spectre/Meltdown mitigations or SMT, watching resources, playing around with sysctl switches, etc.). In the future this job could be, theoretically, replaced by a Fedora VM in OpenNebula, but until then I'd really welcome a way to avoid using *.dusty nodes for this particular job to get rid of flakiness in the test suite.

As I'm well aware that you have hands full of upgrades for the current CentOS CI infra, I didn't want to come empty handed, thus this PR; hopefully it makes at least some sense. ~~If so, extending it to support multiple patterns/hostnames (comma separated, for example), would be useful as well.~~ Done in the second commit.

