### PR TITLE
Fixes for the python3 deployment of duffy

### DIFF
--- a/duffy/models/baremetal_nodes.py
+++ b/duffy/models/baremetal_nodes.py
@@ -3,7 +3,7 @@ import datetime
 import uuid
 
 from duffy.database import db, Duffyv1Model
-from nodes import *
+from .nodes import *
 
 
 class Host(Duffyv1Model):

--- a/duffy/models/nodes.py
+++ b/duffy/models/nodes.py
@@ -40,7 +40,7 @@ class SessionSchema(marshmallow.Schema):
     id = ma.fields.String(dump_to='ssid')
     hosts = ma.fields.Nested("HostSchema", only='hostname', many=True)
 
-class HostSchema(marshmallow.ModelSchema):
+class HostSchema(marshmallow.Schema):
     session_id = ma.fields.String(dump_to='comment')
 
     class Meta:

--- a/duffy/models/openstack_nodes.py
+++ b/duffy/models/openstack_nodes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from duffy.database import db, Duffyv1Model
-from nodes import *
+from .nodes import *
 
 
 class openstack_host(Duffyv1Model):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setuptools.setup(
     license='Apache 2.0',
 
     install_requires=[
-        'beanstalkc',
+#        'beanstalkc',
         'flask',
         'flask-marshmallow',
         'flask-migrate',


### PR DESCRIPTION
beanstalkc is commented out, because it's not python3 compatible.

Signed-off-by: Michal Konečný <mkonecny@redhat.com>