### PR TITLE
Specified HTTP method inside of the decorator

### DIFF
--- a/src/duffy/main.py
+++ b/src/duffy/main.py
@@ -38,53 +38,56 @@ except Exception:
 main = Flask(__name__)
 
 
-@main.route("/")
+@main.get("/")
 def index():
     return "Index route"
 
 
-@main.route("/api/v2/node", methods=["GET"])
-def api_node_get():
+@main.get("/api/v2/node")
+@main.post("/api/v2/node")
+@main.put("/api/v2/node")
+@main.delete("/api/v2/node")
+def api_node():
     """
     this is what black compliant code looks like kids!
     """
-    apikey = request.args.get("apikey")
-    if apikey == "letmein":
-        return dumps({"msg": "authorised"})
-    return dumps({"msg": "unauthorised"})
-
-
-@main.route("/api/v2/node", methods=["POST"])
-def api_node_post():
-    """
-    this is what black compliant code looks like kids!
-    """
-    apikey = request.form["apikey"]
-    if apikey == "letmein":
-        return dumps({"msg": "authorised"})
-    return dumps({"msg": "unauthorised"})
-
-
-@main.route("/api/v2/node", methods=["PUT"])
-def api_node_put():
-    """
-    this is what black compliant code looks like kids!
-    """
-    apikey = request.form["apikey"]
-    if apikey == "letmein":
-        return dumps({"msg": "authorised"})
-    return dumps({"msg": "unauthorised"})
-
-
-@main.route("/api/v2/node", methods=["DELETE"])
-def api_node_delete():
-    """
-    this is what black compliant code looks like kids!
-    """
-    apikey = request.form["apikey"]
-    if apikey == "letmein":
-        return dumps({"msg": "authorised"})
-    return dumps({"msg": "unauthorised"})
+    if request.method == "GET":
+        """
+        GET method
+        """
+        apikey = request.args.get("apikey")
+        if apikey == "letmein":
+            return dumps({"msg": "authorised"})
+        return dumps({"msg": "unauthorised"})
+    elif request.method == "POST":
+        """
+        POST method
+        """
+        apikey = request.form["apikey"]
+        if apikey == "letmein":
+            return dumps({"msg": "authorised"})
+        return dumps({"msg": "unauthorised"})
+    elif request.method == "PUT":
+        """
+        PUT method
+        """
+        apikey = request.form["apikey"]
+        if apikey == "letmein":
+            return dumps({"msg": "authorised"})
+        return dumps({"msg": "unauthorised"})
+    elif request.method == "DELETE":
+        """
+        DELETE method
+        """
+        apikey = request.form["apikey"]
+        if apikey == "letmein":
+            return dumps({"msg": "authorised"})
+        return dumps({"msg": "unauthorised"})
+    else:
+        """
+        MISC method
+        """
+        return dumps({"msg": "bad method"})
 
 
 @main.errorhandler(404)
@@ -106,12 +109,8 @@ def e500page(ertx):
 
 
 @click.command()
-@click.option(
-    "-p", "--portdata", "portdata", help="Set the port value [0-65536]", default="9696"
-)
-@click.version_option(
-    version=duffy_version, prog_name=click.style("CentOS/Duffy", fg="magenta")
-)
+@click.option("-p", "--portdata", "portdata", help="Set the port value [0-65536]", default="9696")
+@click.version_option(version=duffy_version, prog_name=click.style("CentOS/Duffy", fg="magenta"))
 def uptownfunc(portdata):
     """
     Uptownfucn gonna give Duffy to ya


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

Complies with the new Flask 2.0 syntax.

Check it with the following commands after your server has started.
```
Python 3.9.6 (default, Jul 16 2021, 00:00:00) 
[GCC 11.1.1 20210531 (Red Hat 11.1.1-3)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import requests
>>> r = requests.get("http://192.168.0.163:9696")
>>> r.text
'Index route'
>>> r = requests.get("http://192.168.0.163:9696/api/v2/node", params={"apikey":"letmein"})
>>> r.json()
{'msg': 'authorised'}
>>> r = requests.get("http://192.168.0.163:9696/api/v2/node", params={"apikey":"letmeout"})
>>> r.json()
>>> r = requests.put("http://192.168.0.163:9696/api/v2/node", data={"apikey":"letmeout"})
>>> r.json()
{'msg': 'unauthorised'}
>>> r = requests.put("http://192.168.0.163:9696/api/v2/node", data={"apikey":"letmein"})
>>> r.json()
>>> r = requests.post("http://192.168.0.163:9696/api/v2/node", data={"apikey":"letmein"})
>>> r.json()
{'msg': 'authorised'}
>>> r = requests.post("http://192.168.0.163:9696/api/v2/node", data={"apikey":"letmeout"})
>>> r.json()
{'msg': 'unauthorised'}
>>> r = requests.delete("http://192.168.0.163:9696/api/v2/node", data={"apikey":"letmein"})
>>> r.json()
{'msg': 'authorised'}
>>> r = requests.delete("http://192.168.0.163:9696/api/v2/node", data={"apikey":"letmeout"})
>>> r.json()
{'msg': 'unauthorised'}
```