### PR TITLE
Set up Tox

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -22,13 +22,10 @@ jobs:
              source duffy/bin/activate
              python -m pip install --upgrade poetry
              python -m pip install --upgrade pytest
+             python -m pip install --upgrade tox
 
-      - name: install dependencies via poetry
+
+      - name: execute tox
         run: |
              source duffy/bin/activate
-             poetry install
-
-      - name: Run pytest
-        run: |
-             source duffy/bin/activate
-             pytest
+             tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,2 +1,17 @@
+[tox]
+minversion = 3.6.0
+envlist = py{36,37,38,39}
+isolated_build = true
+skip_missing_interpreters = true
+
+[testenv]
+skip_install = true
+sitepackages = false
+whitelist_externals = poetry
+commands =
+  poetry install
+  duffy --version
+  pytest
+
 [flake8]
-line-length = 100
+max-line-length = 100


### PR DESCRIPTION
Add Tox as a development dependency.
Tox set up to execute tests on Python versions 3.6 - 3.9.

Signed-off-by: Ben Capper <BenCapper19@gmail.com>