### PR TITLE
Set up and initialize database

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -19,13 +19,13 @@ jobs:
       - name: setup venv
         run: |
              python -m pip install --upgrade virtualenv
-             virtualenv duffy
-             source duffy/bin/activate
+             virtualenv venv
+             source venv/bin/activate
              which python
 
       - name: Install base dependencies
         run: |
-             source duffy/bin/activate
+             source venv/bin/activate
              python -m pip install --upgrade poetry
              python -m pip install --upgrade pytest
              python -m pip install --upgrade tox
@@ -33,5 +33,5 @@ jobs:
 
       - name: execute tox
         run: |
-             source duffy/bin/activate
+             source venv/bin/activate
              tox

--- a/duffy/app/main.py
+++ b/duffy/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI
 import logging
+
+from fastapi import FastAPI
 
 log = logging.getLogger(__name__)
 app = FastAPI()

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -11,6 +11,9 @@ DEFAULT_CONFIG_FILE = "/etc/duffy.yaml"
 log = logging.getLogger(__name__)
 
 
+# Global setup and CLI options
+
+
 def init_config(ctx, param, filename):
     try:
         read_configuration(filename)
@@ -19,7 +22,7 @@ def init_config(ctx, param, filename):
     ctx.default_map = config
 
 
-@click.command(name="duffy")
+@click.group(name="duffy")
 @click.option(
     "-c",
     "--config",
@@ -32,11 +35,6 @@ def init_config(ctx, param, filename):
     show_default=True,
 )
 @click.option(
-    "--reload/--no-reload", default=False, help="Automatically reload if the code is changed."
-)
-@click.option("-H", "--host", help="Set the host address to listen on.")
-@click.option("-p", "--port", type=click.IntRange(1, 65535, clamp=True), help="Set the port value.")
-@click.option(
     "-l",
     "--loglevel",
     "loglevel",
@@ -45,26 +43,54 @@ def init_config(ctx, param, filename):
     default="info",
 )
 @click.version_option(version=__version__, prog_name="Duffy")
-def main(reload, host, port, loglevel):
-    """
+@click.pass_context
+def cli(ctx, loglevel):
+    # ensure that ctx.obj exists and is a dict (in case `cli()` is called
+    # by means other than serve() below)
+    ctx.ensure_object(dict)
+
+    ctx.obj["loglevel"] = loglevel
+    ctx.obj["numeric_loglevel"] = numeric_loglevel = uvicorn.config.LOG_LEVELS[loglevel.lower()]
+    logging.basicConfig(level=numeric_loglevel)
+
+
+# Run the web app
+
+
+@cli.command()
+@click.option(
+    "--reload/--no-reload", default=False, help="Automatically reload if the code is changed."
+)
+@click.option("-H", "--host", default="127.0.0.1", help="Set the host address to listen on.")
+@click.option(
+    "-p",
+    "--port",
+    type=click.IntRange(1, 65535, clamp=True),
+    default=8080,
+    help="Set the port value.",
+)
+@click.pass_context
+def serve(ctx, reload, host, port):
+    """Run the Duffy web application server.
+
     Duffy is the middle layer running ci.centos.org that manages the
     provisioning, maintenance and teardown / rebuild of the Nodes
     (physical hardware for now, VMs coming soon) that are used to run
     the tests in the CI Cluster.
     """
+    loglevel = ctx.obj["loglevel"]
+    numeric_loglevel = ctx.obj["numeric_loglevel"]
+
     # Report for duty
     print(" * Starting Duffy...")
     print(f" * Host address : {host}")
     print(f" * Port number  : {port}")
     print(f" * Log level    : {loglevel}")
-
-    numeric_loglevel = uvicorn.config.LOG_LEVELS[loglevel.lower()]
+    print(f" * Serving API docs on http://{host}:{port}/docs")
 
     uvicorn_log_config = config.get("logging", uvicorn.config.LOGGING_CONFIG).copy()
     if uvicorn_log_config.get("loggers", {}).get("duffy"):
         uvicorn_log_config["loggers"]["duffy"]["level"] = numeric_loglevel
-
-    logging.basicConfig(level=numeric_loglevel)
 
     # Start the show
     uvicorn.run(

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -4,6 +4,7 @@ import click
 import uvicorn
 
 from .configuration import config, read_configuration
+from .database.setup import setup_db_schema
 from .version import __version__
 
 DEFAULT_CONFIG_FILE = "/etc/duffy.yaml"
@@ -52,6 +53,15 @@ def cli(ctx, loglevel):
     ctx.obj["loglevel"] = loglevel
     ctx.obj["numeric_loglevel"] = numeric_loglevel = uvicorn.config.LOG_LEVELS[loglevel.lower()]
     logging.basicConfig(level=numeric_loglevel)
+
+
+# Set up the database tables
+
+
+@cli.command()
+def setup_db():
+    """Create tables from the database model."""
+    setup_db_schema()
 
 
 # Run the web app

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -3,8 +3,8 @@ import logging
 import click
 import uvicorn
 
-from ..configuration import config, read_configuration
-from ..version import __version__
+from .configuration import config, read_configuration
+from .version import __version__
 
 DEFAULT_CONFIG_FILE = "/etc/duffy.yaml"
 

--- a/duffy/database/setup.py
+++ b/duffy/database/setup.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+# Import the DB model here so its classes are considered by metadata.create_all() below.
+from ..database import model  # noqa: F401
+from . import get_sync_engine, metadata
+
+HERE = Path(__file__).parent
+
+
+def setup_db_schema():
+    engine = get_sync_engine()
+    with engine.begin():
+        print("Creating database schema")
+        metadata.create_all(bind=engine)

--- a/duffy/exceptions.py
+++ b/duffy/exceptions.py
@@ -1,0 +1,6 @@
+class DuffyException(Exception):  # pragma: no cover
+    """Custom exceptions for Duffy."""
+
+
+class DuffyConfigurationError(DuffyException):  # pragma: no cover
+    """Something's wrong with the configuration of Duffy."""

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -2,6 +2,11 @@
 loglevel: warning
 host: 0.0.0.0
 port: 8080
+database:
+  sqlalchemy:
+    sync_url: "sqlite:///:memory:"
+    # the DB dialect must be async-compatible
+    async_url: "sqlite+aiosqlite:///:memory:"
 logging:
   version: 1
   disable_existing_loggers: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,15 +1,4 @@
 [[package]]
-name = "aiocontextvars"
-version = "0.2.2"
-description = "Asyncio support for PEP-567 contextvars backport."
-category = "dev"
-optional = false
-python-versions = ">=3.5"
-
-[package.dependencies]
-contextvars = {version = "2.4", markers = "python_version < \"3.7\""}
-
-[[package]]
 name = "aiosqlite"
 version = "0.17.0"
 description = "asyncio bridge to the standard sqlite3 module"
@@ -29,7 +18,6 @@ optional = false
 python-versions = ">=3.6.2"
 
 [package.dependencies]
-dataclasses = {version = "*", markers = "python_version < \"3.7\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
 trio = {version = ">=0.16", optional = true, markers = "extra == \"trio\""}
@@ -109,7 +97,6 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 click = ">=7.1.2"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0,<1"
 platformdirs = ">=2"
@@ -179,25 +166,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-name = "contextlib2"
-version = "21.6.0"
-description = "Backports and enhancements for the contextlib module"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[[package]]
-name = "contextvars"
-version = "2.4"
-description = "PEP 567 Backport"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-immutables = ">=0.9"
-
-[[package]]
 name = "coverage"
 version = "6.1.2"
 description = "Code coverage measurement for Python"
@@ -220,7 +188,6 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-aiocontextvars = {version = "*", markers = "python_version < \"3.7\""}
 aiosqlite = {version = "*", optional = true, markers = "extra == \"sqlite\""}
 sqlalchemy = ">=1.4,<1.5"
 
@@ -229,14 +196,6 @@ mysql = ["aiomysql"]
 postgresql = ["asyncpg"]
 postgresql_aiopg = ["aiopg"]
 sqlite = ["aiosqlite"]
-
-[[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "distlib"
@@ -300,7 +259,6 @@ python-multipart = {version = ">=0.0.5,<0.0.6", optional = true, markers = "extr
 requests = {version = ">=2.24.0,<3.0.0", optional = true, markers = "extra == \"test\""}
 sqlalchemy = {version = ">=1.3.18,<1.5.0", optional = true, markers = "extra == \"test\""}
 starlette = "0.16.0"
-types-dataclasses = {version = "0.1.7", optional = true, markers = "extra == \"test\" and python_version < \"3.7\""}
 types-orjson = {version = "3.6.0", optional = true, markers = "extra == \"test\""}
 types-ujson = {version = "0.1.1", optional = true, markers = "extra == \"test\""}
 ujson = {version = ">=4.0.1,<5.0.0", optional = true, markers = "extra == \"test\""}
@@ -399,7 +357,6 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-async-generator = {version = "*", markers = "python_version < \"3.7\""}
 certifi = "*"
 httpcore = ">=0.13.3,<0.14.0"
 rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
@@ -418,20 +375,6 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
-name = "immutables"
-version = "0.16"
-description = "Immutable Collections"
-category = "main"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-typing-extensions = {version = ">=3.7.4.3", markers = "python_version < \"3.8\""}
-
-[package.extras]
-test = ["flake8 (>=3.8.4,<3.9.0)", "pycodestyle (>=2.6.0,<2.7.0)", "mypy (>=0.910)", "pytest (>=6.2.4,<6.3.0)"]
-
-[[package]]
 name = "importlib-metadata"
 version = "4.8.2"
 description = "Read metadata from Python packages"
@@ -447,21 +390,6 @@ zipp = ">=0.5"
 docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
-
-[[package]]
-name = "importlib-resources"
-version = "5.3.0"
-description = "Read resources from Python packages"
-category = "dev"
-optional = false
-python-versions = ">=3.6"
-
-[package.dependencies]
-zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
-
-[package.extras]
-docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [[package]]
 name = "iniconfig"
@@ -655,7 +583,6 @@ optional = false
 python-versions = ">=3.6.1"
 
 [package.dependencies]
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
@@ -699,6 +626,20 @@ toml = "*"
 
 [package.extras]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
+
+[[package]]
+name = "pytest-asyncio"
+version = "0.16.0"
+description = "Pytest support for asyncio."
+category = "dev"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+pytest = ">=5.4.0"
+
+[package.extras]
+testing = ["coverage", "hypothesis (>=5.7.1)"]
 
 [[package]]
 name = "pytest-black"
@@ -829,9 +770,6 @@ category = "main"
 optional = false
 python-versions = ">=3.5"
 
-[package.dependencies]
-contextvars = {version = ">=2.1", markers = "python_version < \"3.7\""}
-
 [[package]]
 name = "sortedcontainers"
 version = "2.4.0"
@@ -883,7 +821,6 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 anyio = ">=3.0.0,<4"
-contextlib2 = {version = ">=21.6.0", markers = "python_version < \"3.7\""}
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
@@ -940,7 +877,6 @@ python-versions = ">=3.6"
 async-generator = ">=1.9"
 attrs = ">=19.2.0"
 cffi = {version = ">=1.14", markers = "os_name == \"nt\" and implementation_name != \"pypy\""}
-contextvars = {version = ">=2.1", markers = "python_version < \"3.7\""}
 idna = "*"
 outcome = "*"
 sniffio = "*"
@@ -950,14 +886,6 @@ sortedcontainers = "*"
 name = "typed-ast"
 version = "1.4.3"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[[package]]
-name = "types-dataclasses"
-version = "0.1.7"
-description = "Typing stubs for dataclasses"
 category = "dev"
 optional = false
 python-versions = "*"
@@ -1037,7 +965,6 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 distlib = ">=0.3.1,<1"
 filelock = ">=3.0.0,<4"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
-importlib-resources = {version = ">=1.0", markers = "python_version < \"3.7\""}
 platformdirs = ">=2,<3"
 six = ">=1.9.0,<2"
 
@@ -1052,9 +979,6 @@ description = "The comprehensive WSGI web application library."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
-
-[package.dependencies]
-dataclasses = {version = "*", markers = "python_version < \"3.7\""}
 
 [package.extras]
 watchdog = ["watchdog"]
@@ -1073,14 +997,10 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 
 [metadata]
 lock-version = "1.1"
-python-versions = "^3.6.2"
-content-hash = "125af7e8c5b68165e24d1bf31f74e594ec6de1a04a544dfc4f7242f9148e6988"
+python-versions = "^3.7"
+content-hash = "d6581943916bc2ed5ae933852ac8f09d3457dd5abaa1b3c69e27aece511927fc"
 
 [metadata.files]
-aiocontextvars = [
-    {file = "aiocontextvars-0.2.2-py2.py3-none-any.whl", hash = "sha256:885daf8261818767d8f7cbd79f9d4482d118f024b6586ef6e67980236a27bfa3"},
-    {file = "aiocontextvars-0.2.2.tar.gz", hash = "sha256:f027372dc48641f683c559f247bd84962becaacdc9ba711d583c3871fb5652aa"},
-]
 aiosqlite = [
     {file = "aiosqlite-0.17.0-py3-none-any.whl", hash = "sha256:6c49dc6d3405929b1d08eeccc72306d3677503cc5e5e43771efc1e00232e8231"},
     {file = "aiosqlite-0.17.0.tar.gz", hash = "sha256:f0e6acc24bc4864149267ac82fb46dfb3be4455f99fe21df82609cc6e6baee51"},
@@ -1181,13 +1101,6 @@ colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
-contextlib2 = [
-    {file = "contextlib2-21.6.0-py2.py3-none-any.whl", hash = "sha256:3fbdb64466afd23abaf6c977627b75b6139a5a3e8ce38405c5b413aed7a0471f"},
-    {file = "contextlib2-21.6.0.tar.gz", hash = "sha256:ab1e2bfe1d01d968e1b7e8d9023bc51ef3509bba217bb730cee3827e1ee82869"},
-]
-contextvars = [
-    {file = "contextvars-2.4.tar.gz", hash = "sha256:f38c908aaa59c14335eeea12abea5f443646216c4e29380d7bf34d2018e2c39e"},
-]
 coverage = [
     {file = "coverage-6.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:675adb3b3380967806b3cbb9c5b00ceb29b1c472692100a338730c1d3e59c8b9"},
     {file = "coverage-6.1.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:95a58336aa111af54baa451c33266a8774780242cab3704b7698d5e514840758"},
@@ -1240,10 +1153,6 @@ coverage = [
 databases = [
     {file = "databases-0.5.3-py3-none-any.whl", hash = "sha256:23862bd96241d8fcbf97eea82995ccb3baa8415c3cb106832b7509f296322f86"},
     {file = "databases-0.5.3.tar.gz", hash = "sha256:b69d74ee0b47fa30bb6e76db0c58da998e973393259d29215d8fb29352162bd6"},
-]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 distlib = [
     {file = "distlib-0.3.3-py2.py3-none-any.whl", hash = "sha256:c8b54e8454e5bf6237cc84c20e8264c3e991e824ef27e8f1e81049867d861e31"},
@@ -1341,42 +1250,9 @@ idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-immutables = [
-    {file = "immutables-0.16-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:acbfa79d44228d96296279068441f980dc63dbed52522d9227ff9f4d96c6627e"},
-    {file = "immutables-0.16-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c9ed003eacb92e630ef200e31f47236c2139b39476894f7963b32bd39bafa3"},
-    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a396314b9024fa55bf83a27813fd76cf9f27dce51f53b0f19b51de035146251"},
-    {file = "immutables-0.16-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:4a2a71678348fb95b13ca108d447f559a754c41b47bd1e7e4fb23974e735682d"},
-    {file = "immutables-0.16-cp36-cp36m-win32.whl", hash = "sha256:064001638ab5d36f6aa05b6101446f4a5793fb71e522bc81b8fc65a1894266ff"},
-    {file = "immutables-0.16-cp36-cp36m-win_amd64.whl", hash = "sha256:1de393f1b188740ca7b38f946f2bbc7edf3910d2048f03bbb8d01f17a038d67c"},
-    {file = "immutables-0.16-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fcf678a3074613119385a02a07c469ec5130559f5ea843c85a0840c80b5b71c6"},
-    {file = "immutables-0.16-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a307eb0984eb43e815dcacea3ac50c11d00a936ecf694c46991cd5a23bcb0ec0"},
-    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7a58825ff2254e2612c5a932174398a4ea8fbddd8a64a02c880cc32ee28b8820"},
-    {file = "immutables-0.16-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:798b095381eb42cf40db6876339e7bed84093e5868018a9e73d8e1f7ab4bb21e"},
-    {file = "immutables-0.16-cp37-cp37m-win32.whl", hash = "sha256:19bdede174847c2ef1292df0f23868ab3918b560febb09fcac6eec621bd4812b"},
-    {file = "immutables-0.16-cp37-cp37m-win_amd64.whl", hash = "sha256:9ccf4c0e3e2e3237012b516c74c49de8872ccdf9129739f7a0b9d7444a8c4862"},
-    {file = "immutables-0.16-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:d59beef203a3765db72b1d0943547425c8318ecf7d64c451fd1e130b653c2fbb"},
-    {file = "immutables-0.16-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0020aaa4010b136056c20a46ce53204e1407a9e4464246cb2cf95b90808d9161"},
-    {file = "immutables-0.16-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edd9f67671555af1eb99ad3c7550238487dd7ac0ac5205b40204ed61c9a922ac"},
-    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:298a301f85f307b4c056a0825eb30f060e64d73605e783289f3df37dd762bab8"},
-    {file = "immutables-0.16-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:b779617f5b94486bfd0f22162cd72eb5f2beb0214a14b75fdafb7b2c908ed0cb"},
-    {file = "immutables-0.16-cp38-cp38-win32.whl", hash = "sha256:511c93d8b1bbbf103ff3f1f120c5a68a9866ce03dea6ac406537f93ca9b19139"},
-    {file = "immutables-0.16-cp38-cp38-win_amd64.whl", hash = "sha256:b651b61c1af6cda2ee201450f2ffe048a5959bc88e43e6c312f4c93e69c9e929"},
-    {file = "immutables-0.16-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:aa7bf572ae1e006104c584be70dc634849cf0dc62f42f4ee194774f97e7fd17d"},
-    {file = "immutables-0.16-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:50793a44ba0d228ed8cad4d0925e00dfd62ea32f44ddee8854f8066447272d05"},
-    {file = "immutables-0.16-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:799621dcdcdcbb2516546a40123b87bf88de75fe7459f7bd8144f079ace6ec3e"},
-    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7bcf52aeb983bd803b7c6106eae1b2d9a0c7ab1241bc6b45e2174ba2b7283031"},
-    {file = "immutables-0.16-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:734c269e82e5f307fb6e17945953b67659d1731e65309787b8f7ba267d1468f2"},
-    {file = "immutables-0.16-cp39-cp39-win32.whl", hash = "sha256:a454d5d3fee4b7cc627345791eb2ca4b27fa3bbb062ccf362ecaaa51679a07ed"},
-    {file = "immutables-0.16-cp39-cp39-win_amd64.whl", hash = "sha256:2505d93395d3f8ae4223e21465994c3bc6952015a38dc4f03cb3e07a2b8d8325"},
-    {file = "immutables-0.16.tar.gz", hash = "sha256:d67e86859598eed0d926562da33325dac7767b7b1eff84e232c22abea19f4360"},
-]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
     {file = "importlib_metadata-4.8.2.tar.gz", hash = "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"},
-]
-importlib-resources = [
-    {file = "importlib_resources-5.3.0-py3-none-any.whl", hash = "sha256:7a65eb0d8ee98eedab76e6deb51195c67f8e575959f6356a6e15fd7e1148f2a3"},
-    {file = "importlib_resources-5.3.0.tar.gz", hash = "sha256:f2e58e721b505a79abe67f5868d99f8886aec8594c962c7490d0c22925f518da"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -1400,9 +1276,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
     {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
@@ -1414,9 +1287,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -1428,9 +1298,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
@@ -1443,9 +1310,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -1458,9 +1322,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -1598,6 +1459,10 @@ pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
+pytest-asyncio = [
+    {file = "pytest-asyncio-0.16.0.tar.gz", hash = "sha256:7496c5977ce88c34379df64a66459fe395cd05543f0a2f837016e7144391fcfb"},
+    {file = "pytest_asyncio-0.16.0-py3-none-any.whl", hash = "sha256:5f2a21273c47b331ae6aa5b36087047b4899e40f03f18397c0e65fa5cca54e9b"},
+]
 pytest-black = [
     {file = "pytest-black-0.3.12.tar.gz", hash = "sha256:1d339b004f764d6cd0f06e690f6dd748df3d62e6fe1a692d6a5500ac2c5b75a5"},
 ]
@@ -1652,9 +1517,7 @@ pyyaml = [
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 regex = [
-    {file = "regex-2021.10.8-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:094a905e87a4171508c2a0e10217795f83c636ccc05ddf86e7272c26e14056ae"},
     {file = "regex-2021.10.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:981c786293a3115bc14c103086ae54e5ee50ca57f4c02ce7cf1b60318d1e8072"},
-    {file = "regex-2021.10.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:b0f2f874c6a157c91708ac352470cb3bef8e8814f5325e3c5c7a0533064c6a24"},
     {file = "regex-2021.10.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51feefd58ac38eb91a21921b047da8644155e5678e9066af7bcb30ee0dca7361"},
     {file = "regex-2021.10.8-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea8de658d7db5987b11097445f2b1f134400e2232cb40e614e5f7b6f5428710e"},
     {file = "regex-2021.10.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1ce02f420a7ec3b2480fe6746d756530f69769292eca363218c2291d0b116a01"},
@@ -1678,9 +1541,7 @@ regex = [
     {file = "regex-2021.10.8-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a37305eb3199d8f0d8125ec2fb143ba94ff6d6d92554c4b8d4a8435795a6eccd"},
     {file = "regex-2021.10.8-cp37-cp37m-win32.whl", hash = "sha256:2efd47704bbb016136fe34dfb74c805b1ef5c7313aef3ce6dcb5ff844299f432"},
     {file = "regex-2021.10.8-cp37-cp37m-win_amd64.whl", hash = "sha256:924079d5590979c0e961681507eb1773a142553564ccae18d36f1de7324e71ca"},
-    {file = "regex-2021.10.8-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:19b8f6d23b2dc93e8e1e7e288d3010e58fafed323474cf7f27ab9451635136d9"},
     {file = "regex-2021.10.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b09d3904bf312d11308d9a2867427479d277365b1617e48ad09696fa7dfcdf59"},
-    {file = "regex-2021.10.8-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:951be934dc25d8779d92b530e922de44dda3c82a509cdb5d619f3a0b1491fafa"},
     {file = "regex-2021.10.8-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f125fce0a0ae4fd5c3388d369d7a7d78f185f904c90dd235f7ecf8fe13fa741"},
     {file = "regex-2021.10.8-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f199419a81c1016e0560c39773c12f0bd924c37715bffc64b97140d2c314354"},
     {file = "regex-2021.10.8-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:09e1031e2059abd91177c302da392a7b6859ceda038be9e015b522a182c89e4f"},
@@ -1688,9 +1549,7 @@ regex = [
     {file = "regex-2021.10.8-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:176796cb7f82a7098b0c436d6daac82f57b9101bb17b8e8119c36eecf06a60a3"},
     {file = "regex-2021.10.8-cp38-cp38-win32.whl", hash = "sha256:5e5796d2f36d3c48875514c5cd9e4325a1ca172fc6c78b469faa8ddd3d770593"},
     {file = "regex-2021.10.8-cp38-cp38-win_amd64.whl", hash = "sha256:e4204708fa116dd03436a337e8e84261bc8051d058221ec63535c9403a1582a1"},
-    {file = "regex-2021.10.8-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6dcf53d35850ce938b4f044a43b33015ebde292840cef3af2c8eb4c860730fff"},
     {file = "regex-2021.10.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b8b6ee6555b6fbae578f1468b3f685cdfe7940a65675611365a7ea1f8d724991"},
-    {file = "regex-2021.10.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e2ec1c106d3f754444abf63b31e5c4f9b5d272272a491fa4320475aba9e8157c"},
     {file = "regex-2021.10.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:973499dac63625a5ef9dfa4c791aa33a502ddb7615d992bdc89cf2cc2285daa3"},
     {file = "regex-2021.10.8-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:88dc3c1acd3f0ecfde5f95c32fcb9beda709dbdf5012acdcf66acbc4794468eb"},
     {file = "regex-2021.10.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4786dae85c1f0624ac77cb3813ed99267c9adb72e59fdc7297e1cf4d6036d493"},
@@ -1809,10 +1668,6 @@ typed-ast = [
     {file = "typed_ast-1.4.3-cp39-cp39-win32.whl", hash = "sha256:209596a4ec71d990d71d5e0d312ac935d86930e6eecff6ccc7007fe54d703808"},
     {file = "typed_ast-1.4.3-cp39-cp39-win_amd64.whl", hash = "sha256:9c6d1a54552b5330bc657b7ef0eae25d00ba7ffe85d9ea8ae6540d2197a3788c"},
     {file = "typed_ast-1.4.3.tar.gz", hash = "sha256:fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65"},
-]
-types-dataclasses = [
-    {file = "types-dataclasses-0.1.7.tar.gz", hash = "sha256:248075d093d8f7c1541ce515594df7ae40233d1340afde11ce7125368c5209b8"},
-    {file = "types_dataclasses-0.1.7-py3-none-any.whl", hash = "sha256:fc372bb68b878ac7a68fd04230d923d4a6303a137ecb0b9700b90630bdfcbfc9"},
 ]
 types-orjson = [
     {file = "types-orjson-3.6.0.tar.gz", hash = "sha256:e8513f75886a13e6061f5658d53d57d97b3af20cb9c3dcee09e31793f3cee28f"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ flake8-max-line-length = 100
 
 [tool.isort]
 line_length = 100
+profile = "black"
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Nils Philippsen <nils@redhat.com>", "Vipul Siddharth <siddharthvipul
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7"
 fastapi = "^0.70.0"
 SQLAlchemy = "^1.4.25"
 importlib-metadata = {version = "^4.8.1", python = "<3.8"}
@@ -25,6 +25,7 @@ pytest-isort = "^2.0.0"
 tox = "^3.24.4"
 fastapi = {version = "^0.70.0", extras = ["test"]}
 flake8 = "^3.9.2"
+pytest-asyncio = "^0.16.0"
 
 [tool.pytest.ini_options]
 addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --flake8 --isort"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-duffy = "duffy.app.cli:main"
+duffy = "duffy.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,4 +42,4 @@ requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]
-duffy = "duffy.cli:main"
+duffy = "duffy.cli:cli"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,8 @@ from typing import Iterator, List, Union
 import pytest
 import yaml
 
+from duffy.configuration import read_configuration
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "duffy_config")
@@ -51,3 +53,8 @@ def duffy_config_files(request: pytest.FixtureRequest) -> Iterator[List[Union[Pa
     # Remove the files.
     for config_file_obj in config_file_objs:
         os.unlink(config_file_obj.name)
+
+
+@pytest.fixture(autouse=True)
+def duffy_config(duffy_config_files):
+    read_configuration(*duffy_config_files)

--- a/tests/database/conftest.py
+++ b/tests/database/conftest.py
@@ -2,11 +2,11 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from duffy.database import Base, DBSession, init_model
+from duffy.database import Base, DBSession, SyncDBSession, init_async_model, init_sync_model
 
 
 @pytest.fixture
-def db_engine():
+def db_sync_engine():
     db_engine = create_engine("sqlite:///:memory:", future=True, echo=True)
     return db_engine
 
@@ -18,26 +18,52 @@ def db_async_engine():
 
 
 @pytest.fixture
-def db_schemas(db_engine):
-    with db_engine.begin():
-        Base.metadata.create_all(db_engine)
+def db_sync_schema(db_sync_engine):
+    with db_sync_engine.begin():
+        Base.metadata.create_all(db_sync_engine)
 
 
 @pytest.fixture
-def db_model_initialized(db_engine, db_schemas):
-    init_model(engine=db_engine)
+async def db_async_schema(db_async_engine):
+    async with db_async_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
 
 
 @pytest.fixture
-def db_obj(request, db_model_initialized):
-    with DBSession.begin():
+def db_sync_model_initialized(db_sync_engine, db_sync_schema):
+    init_sync_model(sync_engine=db_sync_engine)
+
+
+@pytest.fixture
+async def db_async_model_initialized(db_async_engine, db_async_schema):
+    await init_async_model(async_engine=db_async_engine)
+
+
+@pytest.fixture
+def db_sync_obj(request, db_sync_model_initialized):
+    with SyncDBSession.begin():
+        db_obj_dependencies = request.instance._db_obj_get_dependencies()
+        attrs = {**request.instance.attrs, **db_obj_dependencies}
+        obj = request.instance.klass(**attrs)
+        obj._db_obj_dependencies = db_obj_dependencies
+        SyncDBSession.add(obj)
+        SyncDBSession.flush()
+
+        yield obj
+
+        SyncDBSession.rollback()
+
+
+@pytest.fixture
+async def db_async_obj(request, db_async_model_initialized):
+    async with DBSession.begin():
         db_obj_dependencies = request.instance._db_obj_get_dependencies()
         attrs = {**request.instance.attrs, **db_obj_dependencies}
         obj = request.instance.klass(**attrs)
         obj._db_obj_dependencies = db_obj_dependencies
         DBSession.add(obj)
-        DBSession.flush()
+        await DBSession.flush()
 
         yield obj
 
-        DBSession.rollback()
+        await DBSession.rollback()

--- a/tests/database/test___init__.py
+++ b/tests/database/test___init__.py
@@ -1,0 +1,81 @@
+from sys import version_info
+from unittest import mock
+
+if not hasattr(mock, "AsyncMock"):
+    # This is missing on Python 3.7. The tests will be skipped but ensure that decorators don't
+    # break.
+    mock.AsyncMock = None
+
+import pytest
+
+from duffy import database
+
+TEST_CONFIG = {
+    "database": {
+        "sqlalchemy": {
+            "sync_url": "boo",
+            "async_url": "boo",
+        }
+    }
+}
+
+
+@pytest.mark.duffy_config(TEST_CONFIG)
+@mock.patch("duffy.database.SyncDBSession")
+@mock.patch("duffy.database.get_sync_engine")
+def test_init_sync_model(get_sync_engine, SyncDBSession):
+    sentinel = object()
+    get_sync_engine.return_value = sentinel
+
+    database.init_sync_model()
+
+    get_sync_engine.assert_called_once_with()
+    SyncDBSession.remove.assert_called_once_with()
+    SyncDBSession.configure.assert_called_once_with(bind=sentinel)
+
+
+@pytest.mark.skipif(version_info < (3, 8), reason="requires Python >= 3.8")
+@pytest.mark.asyncio
+@pytest.mark.duffy_config(TEST_CONFIG)
+@mock.patch("duffy.database.DBSession", new_callable=mock.AsyncMock)
+@mock.patch("duffy.database.get_async_engine")
+async def test_init_async_model(get_async_engine, DBSession):
+    sentinel = object()
+    get_async_engine.return_value = sentinel
+    # configure() is not an async coroutine, avoid warning
+    DBSession.configure = mock.MagicMock()
+
+    await database.init_async_model()
+
+    get_async_engine.assert_called_once_with()
+    if version_info >= (3, 8, 0):
+        DBSession.remove.assert_awaited_once_with()
+    DBSession.configure.assert_called_once_with(bind=sentinel)
+
+
+@pytest.mark.skipif(version_info < (3, 8), reason="requires Python >= 3.8")
+@pytest.mark.asyncio
+@mock.patch("duffy.database.init_async_model")
+@mock.patch("duffy.database.init_sync_model")
+def test_init_model(init_sync_model, init_async_model):
+    sentinel = object()
+    init_async_model.return_value = sentinel
+
+    database.init_model(sync_engine=sentinel, async_engine=sentinel)
+
+    init_sync_model.assert_called_once_with(sentinel)
+    init_async_model.assert_called_once_with(sentinel)
+
+
+@pytest.mark.duffy_config(TEST_CONFIG)
+@mock.patch("duffy.database.create_engine")
+def test_get_sync_engine(create_engine):
+    database.get_sync_engine()
+    create_engine.assert_called_once_with(url="boo")
+
+
+@pytest.mark.duffy_config(TEST_CONFIG)
+@mock.patch("duffy.database.create_async_engine")
+def test_get_async_engine(create_async_engine):
+    database.get_async_engine()
+    create_async_engine.assert_called_once_with(url="boo")

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -1,0 +1,16 @@
+from unittest import mock
+
+from duffy.database import setup
+
+
+@mock.patch("duffy.database.setup.metadata")
+@mock.patch("duffy.database.setup.get_sync_engine")
+def test_setup_db_schema(get_sync_engine, metadata):
+    engine = mock.MagicMock()
+    get_sync_engine.return_value = engine
+
+    setup.setup_db_schema()
+
+    get_sync_engine.assert_called_once_with()
+    engine.begin.assert_called_once_with()
+    metadata.create_all.assert_called_once_with(bind=engine)

--- a/tests/database/test_util.py
+++ b/tests/database/test_util.py
@@ -4,7 +4,7 @@ import pytest
 from sqlalchemy import Column, Integer
 from sqlalchemy.exc import StatementError
 
-from duffy.database import Base, DBSession
+from duffy.database import Base, SyncDBSession
 from duffy.database.util import DeclEnum
 
 
@@ -51,36 +51,36 @@ class TestEnumSymbol:
         assert UselessEnum.enval1 < UselessEnum.enval2
 
 
-@pytest.mark.usefixtures("db_model_initialized")
+@pytest.mark.usefixtures("db_sync_model_initialized")
 class TestEnum:
     def test_set_enum(self):
         """Test that an enum attribute can be set."""
         obj = UselessThing(useless_enum=UselessEnum.enval1)
-        DBSession.add(obj)
-        DBSession.flush()
+        SyncDBSession.add(obj)
+        SyncDBSession.flush()
 
     def test_set_enum_from_string(self):
         """Test that an attribute can be set from a string."""
         obj = UselessThing(useless_enum="enval2")
-        DBSession.add(obj)
-        DBSession.flush()
+        SyncDBSession.add(obj)
+        SyncDBSession.flush()
 
     def test_set_enum_none(self):
         """Test that an enum attribute can be set to None and retrieved."""
         obj = UselessThing(useless_enum=None)
-        DBSession.add(obj)
-        DBSession.flush()
+        SyncDBSession.add(obj)
+        SyncDBSession.flush()
 
-        DBSession.expire_all()
-        obj = DBSession.query(UselessThing).filter_by(useless_enum=None).one()
+        SyncDBSession.expire_all()
+        obj = SyncDBSession.query(UselessThing).filter_by(useless_enum=None).one()
         assert obj.useless_enum is None
 
     def test_set_invalid_enum_from_string(self):
         """Test that setting an invalid enum string fails."""
         obj = UselessThing(useless_enum="enval3")
-        DBSession.add(obj)
+        SyncDBSession.add(obj)
         with pytest.raises(StatementError) as excinfo:
-            DBSession.flush()
+            SyncDBSession.flush()
         assert excinfo.type == StatementError
         assert "enval3" in str(excinfo.value)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,6 +33,14 @@ def test_cli_suggestion():
     assert "Error: No such option: --helo" in result.output
 
 
+@mock.patch("duffy.cli.setup_db_schema")
+def test_setup_db(setup_db_schema):
+    runner = CliRunner()
+    result = runner.invoke(cli, [f"--config={EXAMPLE_CONFIG.absolute()}", "setup-db"])
+    assert result.exit_code == 0
+    setup_db_schema.assert_called_once_with()
+
+
 @pytest.mark.parametrize(
     "parameters",
     (

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,11 +4,11 @@ from unittest import mock
 import pytest
 from click.testing import CliRunner
 
-from duffy.app.cli import main
+from duffy.cli import main
 from duffy.version import __version__
 
 HERE = Path(__file__).parent
-EXAMPLE_CONFIG = HERE.parent.parent / "etc" / "duffy-example-config.yaml"
+EXAMPLE_CONFIG = HERE.parent / "etc" / "duffy-example-config.yaml"
 
 
 def test_cli_version():
@@ -36,7 +36,7 @@ def test_cli_suggestion():
 @pytest.mark.parametrize(
     "parameters", ((), ("--host=127.0.0.1",), (f"--config={EXAMPLE_CONFIG.absolute()}",))
 )
-@mock.patch("duffy.app.cli.uvicorn.run")
+@mock.patch("duffy.cli.uvicorn.run")
 def test_cli_main(uvicorn_run, parameters):
     runner = CliRunner()
     runner.invoke(main, parameters)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-minversion = 3.6.0
-envlist = py{36,37,38,39,310},black,flake8,isort
+minversion = 3.7.0
+envlist = py{37,38,39,310},black,flake8,isort
 isolated_build = true
 skip_missing_interpreters = true
 
@@ -12,6 +12,12 @@ commands =
   poetry install
   duffy --version
   pytest -o 'addopts=--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html' tests/
+
+[testenv:py37]
+commands =
+  poetry install
+  duffy --version
+  pytest -o addopts= tests/
 
 [testenv:black]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.6.0
-envlist = py{36,37,38,39,310}
+envlist = py{36,37,38,39,310},black,flake8,isort
 isolated_build = true
 skip_missing_interpreters = true
 
@@ -11,7 +11,22 @@ whitelist_externals = poetry
 commands =
   poetry install
   duffy --version
-  pytest tests/
+  pytest -o 'addopts=--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html' tests/
+
+[testenv:black]
+commands =
+  pip -q install black
+  black --diff duffy/ tests/
+
+[testenv:flake8]
+commands =
+  pip -q install flake8
+  flake8 duffy/ tests/
+
+[testenv:isort]
+commands =
+  pip -q install isort
+  isort --diff duffy/ tests/
 
 [flake8]
 max-line-length = 100


### PR DESCRIPTION
Fixes: #95 

This comes with setting up the `duffy` CLI to use sub-commands for different things: running the app, setting up the database, applying DB migrations, …

Additionally some generic changes:
- Rename virtualenv directory in GitHub actions
- Make tox runs less redundant
- Add duffy_config fixture and apply globally
- Make isort and black coexist well
- Fix import order

---------

How to test:

* Activate your virtual environment
* Run the test suite 😉
  ```
  tox
  ```

Manual tests:

* Copy the example configuration file…
  ```
  cp etc/duffy-example-config.yaml etc/duffy-config.yaml
  ```
* … and edit `database.sqlalchemy.*_url` to point to a real file, e.g. `devdata.db`:
  ```
  database:
    sqlalchemy:
      sync_url: "sqlite:///devdata.db"
      async_url: "sqlite+aiosqlite:///devdata.db"
  ```
* Set up the database, i.e. create tables from the DB model
  ```
  duffy -c etc/duffy-config.yaml setup-db
  ```
  The configured database file `devdata.db` should contain tables corresponding to what's defined in `duffy.database.model`, you can verify that in `sqlite3` with the command `.tables` or using the `sqliteman` GUI. 
* Run the app to serve the API:
  ```
  duffy --config etc/duffy-config.yaml serve --reload
  ```
  It should serve requests on http://127.0.0.1:8080