### PR TITLE
Make setup-db fail if tables are present

### DIFF
--- a/duffy/database/setup.py
+++ b/duffy/database/setup.py
@@ -1,7 +1,9 @@
+import sys
 from pathlib import Path
 
 import alembic.command
 import alembic.config
+from sqlalchemy import inspect
 
 from ..configuration import config
 
@@ -14,6 +16,16 @@ HERE = Path(__file__).parent
 
 def setup_db_schema():
     engine = get_sync_engine()
+
+    inspection_result = inspect(engine)
+
+    present_tables = sorted(n for n in metadata.tables if inspection_result.has_table(n))
+
+    if present_tables:
+        print(f"Tables already present: {', '.join(present_tables)}", file=sys.stderr)
+        print("Refusing to change database schema.", file=sys.stderr)
+        sys.exit(1)
+
     with engine.begin():
         print("Creating database schema")
         metadata.create_all(bind=engine)

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -4,6 +4,8 @@ import pytest
 
 from duffy.database import setup
 
+from ..util import noop_context
+
 TEST_CONFIG = {
     "database": {
         "sqlalchemy": {
@@ -13,23 +15,41 @@ TEST_CONFIG = {
 }
 
 
+@pytest.mark.parametrize("db_empty", (True, False))
 @pytest.mark.duffy_config(TEST_CONFIG)
 @mock.patch("duffy.database.setup.alembic.command.stamp")
 @mock.patch("duffy.database.setup.alembic.config.Config")
 @mock.patch("duffy.database.setup.metadata")
+@mock.patch("duffy.database.setup.inspect")
 @mock.patch("duffy.database.setup.get_sync_engine")
-def test_setup_db_schema(get_sync_engine, metadata, Config, stamp):
+def test_setup_db_schema(get_sync_engine, inspect, metadata, Config, stamp, db_empty):
     engine = mock.MagicMock()
     get_sync_engine.return_value = engine
+
+    inspection_result = mock.MagicMock()
+    inspection_result.has_table.return_value = not db_empty
+    metadata.tables = {"table1": object(), "table2": object()}
+    inspect.return_value = inspection_result
 
     cfg = mock.MagicMock()
     Config.return_value = cfg
 
-    setup.setup_db_schema()
+    if db_empty:
+        expectation = noop_context()
+    else:
+        expectation = pytest.raises(SystemExit)
 
-    get_sync_engine.assert_called_once_with()
-    engine.begin.assert_called_once_with()
-    metadata.create_all.assert_called_once_with(bind=engine)
-    cfg.set_main_option.assert_any_call("script_location", str(setup.HERE / "migrations"))
-    cfg.set_main_option.assert_any_call("sqlalchemy.url", "boo")
-    stamp.assert_called_once_with(cfg, "head")
+    with expectation:
+        setup.setup_db_schema()
+
+    if db_empty:
+        get_sync_engine.assert_called_once_with()
+        engine.begin.assert_called_once_with()
+        metadata.create_all.assert_called_once_with(bind=engine)
+        cfg.set_main_option.assert_any_call("script_location", str(setup.HERE / "migrations"))
+        cfg.set_main_option.assert_any_call("sqlalchemy.url", "boo")
+        stamp.assert_called_once_with(cfg, "head")
+    else:
+        engine.begin.assert_not_called()
+        metadata.create_all.assert_not_called()
+        Config.assert_not_called()


### PR DESCRIPTION
Fixes: #131

# How to Test

Run `duffy ... setup-db` on a non-empty database (e.g. twice).