### PR TITLE
Make is_admin of tenants truly optional

### DIFF
--- a/duffy/api_models/tenant.py
+++ b/duffy/api_models/tenant.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List
+from typing import List, Optional
 
 from pydantic import BaseModel
 
@@ -10,7 +10,7 @@ from .common import APIResult, CreatableMixin, RetirableMixin
 
 class TenantBase(BaseModel, ABC):
     name: str
-    is_admin: bool
+    is_admin: Optional[bool]
     ssh_key: str
 
     class Config:

--- a/duffy/database/model/node.py
+++ b/duffy/database/model/node.py
@@ -52,7 +52,12 @@ class Node(Base, CreatableMixin, RetirableMixin):
     type = Column(NodeType.db_type(), nullable=False)
     hostname = Column(Text, nullable=False)
     ipaddr = Column(Text, nullable=False)
-    state = Column(NodeState.db_type(), nullable=False, default=NodeState.ready)
+    state = Column(
+        NodeState.db_type(),
+        nullable=False,
+        default=NodeState.ready,
+        server_default=NodeState.ready.value,
+    )
     comment = Column(UnicodeText, nullable=True)
 
 

--- a/duffy/database/model/tenant.py
+++ b/duffy/database/model/tenant.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, Integer, UnicodeText
+from sqlalchemy import Boolean, Column, Integer, UnicodeText, text
 
 from .. import Base
 from ..util import CreatableMixin, RetirableMixin
@@ -9,5 +9,5 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     __mapper_args__ = {"eager_defaults": True}
     id = Column(Integer, primary_key=True, nullable=False)
     name = Column(UnicodeText, unique=True, nullable=False)
-    is_admin = Column(Boolean, nullable=False, default=False)
+    is_admin = Column(Boolean, nullable=False, default=False, server_default=text("FALSE"))
     ssh_key = Column(UnicodeText, nullable=False)

--- a/duffy/database/util.py
+++ b/duffy/database/util.py
@@ -64,7 +64,7 @@ class DeclEnumType(SchemaType, TypeDecorator):
 
     @classmethod
     def _type_name(cls, clsname):
-        return "ck_" + camel_case_to_lower_with_underscores(clsname)
+        return camel_case_to_lower_with_underscores(clsname) + "_enum"
 
     def _set_table(self, table, column):
         self.impl._set_table(table, column)

--- a/tests/app/controllers/__init__.py
+++ b/tests/app/controllers/__init__.py
@@ -44,10 +44,18 @@ class BaseTestController:
                 ...
 
                 response = await self._create_obj(
-                    client, add_attrs={"foo_id": bar1["id"]}
+                    client, attrs={"foo_id": bar1["id"]}
                 )
                 result = response.json()
                 bar2 = result["bar"]
+
+                ...
+
+                response = await self._create_obj(
+                    client, attrs={"new_attrs": {...}}, merge_cls_attrs=False
+                )
+                result = response.json()
+                bar3 = result["bar"]
 
                 ...
     """
@@ -63,8 +71,11 @@ class BaseTestController:
         return self.name + "s"
 
     @classmethod
-    async def _create_obj(cls, client, add_attrs: dict = None):
-        attrs = {**(cls.attrs or {}), **(add_attrs or {})}
+    async def _create_obj(cls, client, attrs: dict = None, merge_cls_attrs: bool = True):
+        if merge_cls_attrs:
+            attrs = {**(cls.attrs or {}), **(attrs or {})}
+        else:
+            attrs = attrs or {}
 
         for name, value in attrs.items():
             try:
@@ -137,7 +148,7 @@ class BaseTestController:
         create_response = await self._create_obj(client)
 
         response = await self._create_obj(
-            client, add_attrs=self._add_attrs_from_response(create_response)
+            client, attrs=self._add_attrs_from_response(create_response)
         )
         if self.unique:
             assert response.status_code == HTTP_409_CONFLICT

--- a/tests/app/controllers/test_node.py
+++ b/tests/app/controllers/test_node.py
@@ -30,7 +30,7 @@ class TestSeaMicroNode(BaseTestController):
     unique = True
 
     async def test_create_unknown_chassis(self, client):
-        response = await self._create_obj(client, add_attrs={"chassis_id": 1})
+        response = await self._create_obj(client, attrs={"chassis_id": 1})
         assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
         result = response.json()
         assert "detail" in result

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -13,7 +13,7 @@ class TestSession(BaseTestController):
     }
 
     async def test_create_unknown_tenant(self, client):
-        response = await self._create_obj(client, add_attrs={"tenant_id": 1})
+        response = await self._create_obj(client, attrs={"tenant_id": 1})
         assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
         result = response.json()
         assert "detail" in result

--- a/tests/app/controllers/test_tenant.py
+++ b/tests/app/controllers/test_tenant.py
@@ -1,3 +1,5 @@
+from starlette.status import HTTP_201_CREATED
+
 from . import BaseTestController
 
 
@@ -7,7 +9,12 @@ class TestTenant(BaseTestController):
     path = "/api/v1/tenants"
     attrs = {
         "name": "Some Honky Tenant!",
-        "is_admin": False,
         "ssh_key": "With a honky SSH key!",
     }
     unique = "unique"
+
+    async def test_with_is_admin_set(self, client):
+        response = await self._create_obj(client, attrs={"is_admin": False})
+        assert response.status_code == HTTP_201_CREATED
+        result = response.json()
+        self._verify_item(result[self.name])


### PR DESCRIPTION
It's False by default, so we shouldn't require it being supplied in POST requests. Didn't notice this in the review :wink:.

Additionally:

- Create better enum type names in the database
- Set server-side defaults for columns with defaults (totally missed this before, oops)
- Make merging attrs optional in ._create_obj() – this lets us specify completely different attributes for creating objects in API tests, rather than values that are added to `attrs` in a test class