### PR TITLE
Handle missing config file error

### DIFF
--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -66,7 +66,11 @@ def cli(ctx, loglevel):
 @cli.command()
 def setup_db():
     """Create tables from the database model."""
-    setup_db_schema()
+    try:
+        setup_db_schema()
+    except DuffyConfigurationError as exc:
+        log.error("Configuration key missing or wrong: %s", exc.args[0])
+        sys.exit(1)
 
 
 # Interactive shell

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -58,9 +58,7 @@ def test_shell(init_model, embed_shell, config_error, shell_type):
         args.append(f"--shell-type={shell_type}")
 
     if config_error:
-        init_model.side_effect = DuffyConfigurationError(
-            "Configuration key missing or wrong: database"
-        )
+        init_model.side_effect = DuffyConfigurationError("database")
 
     runner = CliRunner()
 


### PR DESCRIPTION
Fixes: #139 

- Return a more elegant error message when no config file is passed to the engine

Signed-off-by: Ben Capper <BenCapper19@gmail.com>