### PR TITLE
Session workflow

### DIFF
--- a/duffy/api_models/__init__.py
+++ b/duffy/api_models/__init__.py
@@ -18,12 +18,14 @@ from .node import (  # noqa: F401
     concrete_node_models,
 )
 from .session import (  # noqa: F401
+    PhysicalNodesSpec,
     PhysicalSessionNodeModel,
     SessionCreateModel,
     SessionModel,
     SessionNodeModel,
     SessionResult,
     SessionResultCollection,
+    VirtualNodesSpec,
     VirtualSessionNodeModel,
 )
 from .tenant import (  # noqa: F401

--- a/duffy/api_models/__init__.py
+++ b/duffy/api_models/__init__.py
@@ -18,10 +18,13 @@ from .node import (  # noqa: F401
     concrete_node_models,
 )
 from .session import (  # noqa: F401
+    PhysicalSessionNodeModel,
     SessionCreateModel,
     SessionModel,
+    SessionNodeModel,
     SessionResult,
     SessionResultCollection,
+    VirtualSessionNodeModel,
 )
 from .tenant import (  # noqa: F401
     TenantCreateModel,

--- a/duffy/api_models/__init__.py
+++ b/duffy/api_models/__init__.py
@@ -25,6 +25,7 @@ from .session import (  # noqa: F401
     SessionNodeModel,
     SessionResult,
     SessionResultCollection,
+    SessionUpdateModel,
     VirtualNodesSpec,
     VirtualSessionNodeModel,
 )

--- a/duffy/api_models/node.py
+++ b/duffy/api_models/node.py
@@ -15,6 +15,8 @@ class NodeBase(BaseModel, ABC):
     hostname: str
     ipaddr: IPvAnyAddress
     comment: Optional[str]
+    distro_type: Optional[str]
+    distro_version: Optional[str]
 
     class Config:
         orm_mode = True

--- a/duffy/api_models/node.py
+++ b/duffy/api_models/node.py
@@ -3,7 +3,7 @@ from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, IPvAnyAddress
 
-from ..database.model import NodeState, NodeType, VirtualNodeFlavour
+from ..database.types import NodeState, NodeType, VirtualNodeFlavour
 from .chassis import ChassisModel
 from .common import APIResult, CreatableMixin, RetirableMixin
 

--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -1,12 +1,31 @@
 from abc import ABC
 from typing import List, Literal, Union
 
-from pydantic import BaseModel
+from pydantic import BaseModel, conint
 
 from ..database.types import NodeType, VirtualNodeFlavour
 from .common import APIResult, CreatableMixin, RetirableMixin
 from .node import NodeBase
 from .tenant import TenantModel
+
+# nodes spec model
+
+
+class NodesSpecBase(BaseModel, ABC):
+    type: NodeType
+    quantity: conint(ge=1)
+    distro_type: str
+    distro_version: str
+
+
+class VirtualNodesSpec(NodesSpecBase):
+    type: Literal[NodeType.virtual]
+    flavour: VirtualNodeFlavour
+
+
+class PhysicalNodesSpec(NodesSpecBase):
+    type: Literal[NodeType.physical]
+
 
 # nodes in sessions model
 
@@ -41,6 +60,7 @@ class SessionBase(BaseModel, ABC):
 
 class SessionCreateModel(SessionBase):
     tenant_id: int
+    nodes_specs: List[Union[PhysicalNodesSpec, VirtualNodesSpec]]
 
 
 class SessionModel(SessionBase, CreatableMixin, RetirableMixin):

--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -63,6 +63,10 @@ class SessionCreateModel(SessionBase):
     nodes_specs: List[Union[PhysicalNodesSpec, VirtualNodesSpec]]
 
 
+class SessionUpdateModel(SessionBase):
+    active: bool
+
+
 class SessionModel(SessionBase, CreatableMixin, RetirableMixin):
     id: int
     tenant: TenantModel

--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -1,10 +1,35 @@
 from abc import ABC
-from typing import List
+from typing import List, Literal, Union
 
 from pydantic import BaseModel
 
+from ..database.types import NodeType, VirtualNodeFlavour
 from .common import APIResult, CreatableMixin, RetirableMixin
+from .node import NodeBase
 from .tenant import TenantModel
+
+# nodes in sessions model
+
+
+class SessionNodeBase(NodeBase, ABC):
+    distro_type: str
+    distro_version: str
+
+    class Config:
+        orm_mode = True
+
+
+class PhysicalSessionNodeModel(SessionNodeBase):
+    type: Literal[NodeType.seamicro]
+
+
+class VirtualSessionNodeModel(SessionNodeBase):
+    type: Literal[NodeType.opennebula]
+    flavour: VirtualNodeFlavour
+
+
+SessionNodeModel = Union[PhysicalSessionNodeModel, VirtualSessionNodeModel]
+
 
 # session model
 
@@ -21,6 +46,7 @@ class SessionCreateModel(SessionBase):
 class SessionModel(SessionBase, CreatableMixin, RetirableMixin):
     id: int
     tenant: TenantModel
+    nodes: List[SessionNodeModel]
 
 
 # API results

--- a/duffy/app/controllers/chassis.py
+++ b/duffy/app/controllers/chassis.py
@@ -2,37 +2,40 @@
 This is the chassis controller.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_409_CONFLICT
 
 from ...api_models import ChassisCreateModel, ChassisResult, ChassisResultCollection
-from ...database import DBSession
 from ...database.model import Chassis
+from ..database import req_db_async_session
 
 router = APIRouter(prefix="/chassis")
 
 
 # http get http://localhost:8080/api/v1/chassis
 @router.get("", response_model=ChassisResultCollection, tags=["chassis"])
-async def get_all_chassis():
+async def get_all_chassis(db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Return all chassis
     """
     query = select(Chassis)
-    results = await DBSession.execute(query)
+    results = await db_async_session.execute(query)
 
     return {"action": "get", "chassis": results.scalars().all()}
 
 
 # http get http://localhost:8080/api/v1/chassis/2
 @router.get("/{id}", response_model=ChassisResult, tags=["chassis"])
-async def get_chassis(id: int):
+async def get_chassis(id: int, db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Return the chassis with the specified **ID**
     """
-    chassis = (await DBSession.execute(select(Chassis).filter_by(id=id))).scalar_one_or_none()
+    chassis = (
+        await db_async_session.execute(select(Chassis).filter_by(id=id))
+    ).scalar_one_or_none()
 
     if not chassis:
         raise HTTPException(HTTP_404_NOT_FOUND)
@@ -43,15 +46,18 @@ async def get_chassis(id: int):
 # http --json post http://localhost:8080/api/v1/chassis name="A Chassis with a unique name" \
 #      description="A funky but optional description."
 @router.post("", status_code=HTTP_201_CREATED, response_model=ChassisResult, tags=["chassis"])
-async def create_chassis(data: ChassisCreateModel):
+async def create_chassis(
+    data: ChassisCreateModel,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+):
     """
     Create a chassis with the specified **name** and optional **description**
     """
     chassis = Chassis(name=data.name, description=data.description)
 
-    DBSession.add(chassis)
+    db_async_session.add(chassis)
     try:
-        await DBSession.commit()
+        await db_async_session.commit()
     except IntegrityError as exc:
         raise HTTPException(HTTP_409_CONFLICT, str(exc))
 
@@ -60,16 +66,18 @@ async def create_chassis(data: ChassisCreateModel):
 
 # http delete http://localhost:8080/api/v1/chassis/2
 @router.delete("/{id}", response_model=ChassisResult, tags=["chassis"])
-async def delete_chassis(id: int):
+async def delete_chassis(id: int, db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Delete the chassis with the specified **ID**
     """
-    chassis = (await DBSession.execute(select(Chassis).filter_by(id=id))).scalar_one_or_none()
+    chassis = (
+        await db_async_session.execute(select(Chassis).filter_by(id=id))
+    ).scalar_one_or_none()
 
     if not chassis:
         raise HTTPException(HTTP_404_NOT_FOUND)
 
-    await DBSession.delete(chassis)
-    await DBSession.commit()
+    await db_async_session.delete(chassis)
+    await db_async_session.commit()
 
     return {"action": "delete", "chassis": chassis}

--- a/duffy/app/controllers/session.py
+++ b/duffy/app/controllers/session.py
@@ -2,9 +2,10 @@
 This is the session controller.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_422_UNPROCESSABLE_ENTITY
 
@@ -15,16 +16,16 @@ from ...api_models import (
     SessionResultCollection,
     SessionUpdateModel,
 )
-from ...database import DBSession
 from ...database.model import PhysicalNode, Session, SessionNode, Tenant, VirtualNode
 from ...database.types import NodeState
+from ..database import req_db_async_session
 
 router = APIRouter(prefix="/sessions")
 
 
 # http get http://localhost:8080/api/v1/sessions
 @router.get("", response_model=SessionResultCollection, tags=["sessions"])
-async def get_all_sessions():
+async def get_all_sessions(db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Returns all sessions
     """
@@ -32,18 +33,18 @@ async def get_all_sessions():
         selectinload(Session.tenant),
         selectinload(Session.session_nodes).selectinload(SessionNode.node),
     )
-    results = await DBSession.execute(query)
+    results = await db_async_session.execute(query)
     return {"action": "get", "sessions": results.scalars().all()}
 
 
 # http get http://localhost:8080/api/v1/sessions/2
 @router.get("/{id}", response_model=SessionResult, tags=["sessions"])
-async def get_session(id: int):
+async def get_session(id: int, db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Returns a session with the specified **ID**
     """
     session = (
-        await DBSession.execute(
+        await db_async_session.execute(
             select(Session)
             .filter_by(id=id)
             .options(
@@ -59,23 +60,26 @@ async def get_session(id: int):
 
 # http --json post http://localhost:8080/api/v1/sessions tenant_id=2
 @router.post("", status_code=HTTP_201_CREATED, response_model=SessionResult, tags=["sessions"])
-async def create_session(data: SessionCreateModel):
+async def create_session(
+    data: SessionCreateModel,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+):
     """
     Creates a session with the specified **tenant ID**
     """
     tenant = (
-        await DBSession.execute(select(Tenant).filter_by(id=data.tenant_id))
+        await db_async_session.execute(select(Tenant).filter_by(id=data.tenant_id))
     ).scalar_one_or_none()
 
     if not tenant:
         raise HTTPException(
             HTTP_422_UNPROCESSABLE_ENTITY, f"can't find tenant with id {data.tenant_id}"
         )
-    if not tenant.active:
+    elif not tenant.active:
         raise HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, f"tenant '{tenant.name}' isn't active")
 
     session = Session(tenant=tenant)
-    DBSession.add(session)
+    db_async_session.add(session)
 
     for nodes_spec in data.nodes_specs:
         nodes_spec_dict = nodes_spec.dict()
@@ -91,7 +95,7 @@ async def create_session(data: SessionCreateModel):
             select(node_cls).filter_by(state=NodeState.active, **nodes_spec_dict).limit(quantity)
         )
 
-        nodes_to_reserve = (await DBSession.execute(query)).scalars().all()
+        nodes_to_reserve = (await db_async_session.execute(query)).scalars().all()
 
         if len(nodes_to_reserve) < quantity:
             raise HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, f"can't reserve nodes: {nodes_spec}")
@@ -105,12 +109,12 @@ async def create_session(data: SessionCreateModel):
                 distro_type=nodes_spec.distro_type,
                 distro_version=nodes_spec.distro_version,
             )
-            DBSession.add(session_node)
+            db_async_session.add(session_node)
 
     # Meh. Reload the session instance to be able to explicily load all the related objects.
-    await DBSession.flush()
+    await db_async_session.flush()
     session = (
-        await DBSession.execute(
+        await db_async_session.execute(
             select(Session)
             .filter_by(id=session.id)
             .options(
@@ -121,7 +125,7 @@ async def create_session(data: SessionCreateModel):
     ).scalar_one()
 
     try:
-        await DBSession.commit()
+        await db_async_session.commit()
     except IntegrityError as exc:  # pragma: no cover
         raise HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, str(exc))
     return {"action": "post", "session": session}
@@ -129,9 +133,13 @@ async def create_session(data: SessionCreateModel):
 
 # http --json put http://localhost:8080/api/v1/sessions/2 active:=false
 @router.put("/{id}", response_model=SessionResult, tags=["sessions"])
-async def update_session(id: int, data: SessionUpdateModel):
+async def update_session(
+    id: int,
+    data: SessionUpdateModel,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+):
     session = (
-        await DBSession.execute(
+        await db_async_session.execute(
             select(Session)
             .filter_by(id=id)
             .options(
@@ -153,19 +161,19 @@ async def update_session(id: int, data: SessionUpdateModel):
     for session_node in session.session_nodes:
         session_node.node.state = NodeState.deprovisioning
 
-    await DBSession.commit()
+    await db_async_session.commit()
 
     return {"action": "put", "session": session}
 
 
 # http delete http://localhost:8080/api/v1/sessions/2
 @router.delete("/{id}", response_model=SessionResult, tags=["sessions"])
-async def delete_session(id: int):
+async def delete_session(id: int, db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Deletes the session with the specified **ID**
     """
     session = (
-        await DBSession.execute(
+        await db_async_session.execute(
             select(Session)
             .filter_by(id=id)
             .options(
@@ -176,6 +184,6 @@ async def delete_session(id: int):
     ).scalar_one_or_none()
     if not session:
         raise HTTPException(HTTP_404_NOT_FOUND)
-    await DBSession.delete(session)
-    await DBSession.commit()
+    await db_async_session.delete(session)
+    await db_async_session.commit()
     return {"action": "delete", "session": session}

--- a/duffy/app/controllers/session.py
+++ b/duffy/app/controllers/session.py
@@ -51,10 +51,14 @@ async def create_session(data: SessionCreateModel):
     tenant = (
         await DBSession.execute(select(Tenant).filter_by(id=data.tenant_id))
     ).scalar_one_or_none()
+
     if not tenant:
         raise HTTPException(
             HTTP_422_UNPROCESSABLE_ENTITY, f"can't find tenant with id {data.tenant_id}"
         )
+    if not tenant.active:
+        raise HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, f"tenant '{tenant.name}' isn't active")
+
     session = Session(tenant=tenant)
     DBSession.add(session)
     try:

--- a/duffy/app/controllers/tenant.py
+++ b/duffy/app/controllers/tenant.py
@@ -2,37 +2,41 @@
 This is the tenant controller.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_409_CONFLICT
 
 from ...api_models import TenantCreateModel, TenantResult, TenantResultCollection
-from ...database import DBSession
 from ...database.model import Tenant
+from ..database import req_db_async_session
 
 router = APIRouter(prefix="/tenants")
 
 
 # http get http://localhost:8080/api/v1/tenants
 @router.get("", response_model=TenantResultCollection, tags=["tenants"])
-async def get_all_tenants():
+async def get_all_tenants(db_async_session: AsyncSession = Depends(req_db_async_session)):
     """
     Return all tenants
     """
     query = select(Tenant)
-    results = await DBSession.execute(query)
+    results = await db_async_session.execute(query)
 
     return {"action": "get", "tenants": results.scalars().all()}
 
 
 # http get http://localhost:8080/api/v1/tenants/2
 @router.get("/{id}", response_model=TenantResult, tags=["tenants"])
-async def get_tenant(id: int):
+async def get_tenant(
+    id: int,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+):
     """
     Return the tenant with the specified **ID**
     """
-    tenant = (await DBSession.execute(select(Tenant).filter_by(id=id))).scalar_one_or_none()
+    tenant = (await db_async_session.execute(select(Tenant).filter_by(id=id))).scalar_one_or_none()
 
     if not tenant:
         raise HTTPException(HTTP_404_NOT_FOUND)
@@ -42,16 +46,19 @@ async def get_tenant(id: int):
 
 # http --json post http://localhost:8080/api/v1/tenants name="Unique name"
 @router.post("", status_code=HTTP_201_CREATED, response_model=TenantResult, tags=["tenants"])
-async def create_tenant(data: TenantCreateModel):
+async def create_tenant(
+    data: TenantCreateModel,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+):
     """
     Create a tenant with the specified **name**
     """
     tenant = Tenant(
         name=data.name, is_admin=data.is_admin, api_key=data.api_key, ssh_key=data.ssh_key
     )
-    DBSession.add(tenant)
+    db_async_session.add(tenant)
     try:
-        await DBSession.commit()
+        await db_async_session.commit()
     except IntegrityError as exc:
         raise HTTPException(HTTP_409_CONFLICT, str(exc))
 
@@ -60,16 +67,19 @@ async def create_tenant(data: TenantCreateModel):
 
 # http delete http://localhost:8080/api/v1/tenant/2
 @router.delete("/{id}", response_model=TenantResult, tags=["tenants"])
-async def delete_tenant(id: int):
+async def delete_tenant(
+    id: int,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+):
     """
     Delete the tenant with the specified **ID**
     """
-    tenant = (await DBSession.execute(select(Tenant).filter_by(id=id))).scalar_one_or_none()
+    tenant = (await db_async_session.execute(select(Tenant).filter_by(id=id))).scalar_one_or_none()
 
     if not tenant:
         raise HTTPException(HTTP_404_NOT_FOUND)
 
-    await DBSession.delete(tenant)
-    await DBSession.commit()
+    await db_async_session.delete(tenant)
+    await db_async_session.commit()
 
     return {"action": "delete", "tenant": tenant}

--- a/duffy/app/database.py
+++ b/duffy/app/database.py
@@ -1,0 +1,13 @@
+from typing import Iterator
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from ..database import async_session_maker
+
+
+async def req_db_async_session() -> Iterator[AsyncSession]:
+    db_async_session = async_session_maker()
+    try:
+        yield db_async_session
+    finally:
+        await db_async_session.close()

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -7,7 +7,7 @@ import uvicorn
 
 from . import database, shell
 from .configuration import config, read_configuration
-from .database.setup import setup_db_schema
+from .database.setup import setup_db_schema, setup_db_test_data
 from .exceptions import DuffyConfigurationError
 from .tasks import start_worker
 from .version import __version__
@@ -64,10 +64,16 @@ def cli(ctx, loglevel):
 
 
 @cli.command()
-def setup_db():
+@click.option(
+    "--test-data/--no-test-data", default=False, help="Initialized database with test data."
+)
+def setup_db(test_data):
     """Create tables from the database model."""
     try:
         setup_db_schema()
+        if test_data:
+            database.init_model()
+            setup_db_test_data()
     except DuffyConfigurationError as exc:
         log.error("Configuration key missing or wrong: %s", exc.args[0])
         sys.exit(1)

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -149,12 +149,6 @@ def serve(ctx, reload, host, port):
     if uvicorn_log_config.get("loggers", {}).get("duffy"):
         uvicorn_log_config["loggers"]["duffy"]["level"] = numeric_loglevel
 
-    try:
-        database.init_model()
-    except DuffyConfigurationError as exc:
-        log.error("Configuration key missing or wrong: %s", exc.args[0])
-        sys.exit(1)
-
     # Start the show
     uvicorn.run(
         "duffy.app.main:app",

--- a/duffy/database/model/__init__.py
+++ b/duffy/database/model/__init__.py
@@ -1,9 +1,6 @@
-from .node import VirtualNodeFlavour  # noqa: F401
 from .node import (  # noqa: F401
     Chassis,
     Node,
-    NodeState,
-    NodeType,
     OpenNebulaNode,
     PhysicalNode,
     SeaMicroNode,

--- a/duffy/database/model/node.py
+++ b/duffy/database/model/node.py
@@ -43,6 +43,10 @@ class Node(Base, CreatableMixin, RetirableMixin):
     )
     comment = Column(UnicodeText, nullable=True)
 
+    # currently configured distro type & version
+    distro_type = Column(UnicodeText, nullable=True)
+    distro_version = Column(UnicodeText, nullable=True)
+
 
 class VirtualNode(Node):
     __tablename__ = "virtualnodes"

--- a/duffy/database/model/node.py
+++ b/duffy/database/model/node.py
@@ -2,26 +2,9 @@ from sqlalchemy import Column, ForeignKey, Index, Integer, Text, UnicodeText
 from sqlalchemy.orm import relationship
 
 from .. import Base
-from ..util import CreatableMixin, DeclEnum, RetirableMixin
+from ..types import NodeState, NodeType, VirtualNodeFlavour
+from ..util import CreatableMixin, RetirableMixin
 from .session import Session
-
-
-class NodeType(str, DeclEnum):
-    virtual = "virtual"
-    physical = "physical"
-    opennebula = "opennebula"
-    seamicro = "seamicro"
-
-
-class NodeState(str, DeclEnum):
-    ready = "ready"
-    active = "active"
-    contextualizing = "contextualizing"
-    deployed = "deployed"
-    deprovisioning = "deprovisioning"
-    done = "done"
-    failing = "failing"
-    failed = "failed"
 
 
 class Node(Base, CreatableMixin, RetirableMixin):
@@ -59,12 +42,6 @@ class Node(Base, CreatableMixin, RetirableMixin):
         server_default=NodeState.ready.value,
     )
     comment = Column(UnicodeText, nullable=True)
-
-
-class VirtualNodeFlavour(str, DeclEnum):
-    small = "small"
-    medium = "medium"
-    large = "large"
 
 
 class VirtualNode(Node):

--- a/duffy/database/model/session.py
+++ b/duffy/database/model/session.py
@@ -1,6 +1,9 @@
+from typing import List
+
 from sqlalchemy import Column, ForeignKey, Integer
 from sqlalchemy.orm import relationship
 
+from ...api_models import SessionNodeModel
 from .. import Base
 from ..util import CreatableMixin, RetirableMixin
 from .tenant import Tenant
@@ -12,3 +15,9 @@ class Session(Base, CreatableMixin, RetirableMixin):
     id = Column(Integer, primary_key=True, nullable=False)
     tenant_id = Column(Integer, ForeignKey(Tenant.id), nullable=False)
     tenant = relationship(Tenant, backref="sessions")
+    session_nodes = relationship("SessionNode", back_populates="session")
+
+    @property
+    def nodes(self) -> List[SessionNodeModel]:
+        """Combine info from related session_nodes and their nodes."""
+        return [sn.pydantic_view for sn in self.session_nodes]

--- a/duffy/database/setup.py
+++ b/duffy/database/setup.py
@@ -63,12 +63,16 @@ def _gen_test_data_objs():
             "hostname": "node-seamicro-1.example.net",
             "ipaddr": "192.168.0.11",
             "chassis": chassis,
+            "distro_type": "centos",
+            "distro_version": "8Stream",
         },
         {
             "type": "seamicro",
             "hostname": "node-seamicro-2.example.net",
             "ipaddr": "192.168.0.12",
             "chassis": chassis,
+            "distro_type": "fedora",
+            "distro_version": "35",
         },
     ]
 
@@ -81,12 +85,20 @@ def _gen_test_data_objs():
         lastoctetbase = int(lastoctetbase)
         for index in range(1, quantity + 1):
             lastoctet = lastoctetbase + index
+            if index % 2:
+                distro_type = "fedora"
+                distro_version = "35"
+            else:
+                distro_type = "centos"
+                distro_version = "8Stream"
             node_specs.append(
                 {
                     "type": "opennebula",
                     "hostname": f"node-opennebula-{flavour}-{index}.example.net",
                     "ipaddr": f"{ipprefix}.{lastoctet}",
                     "flavour": flavour,
+                    "distro_type": distro_type,
+                    "distro_version": distro_version,
                 }
             )
 

--- a/duffy/database/setup.py
+++ b/duffy/database/setup.py
@@ -9,7 +9,7 @@ from sqlalchemy import inspect
 from ..configuration import config
 
 # Import the DB model here so its classes are considered by metadata.create_all() below.
-from . import SyncDBSession, get_sync_engine, metadata, model  # noqa: F401
+from . import get_sync_engine, metadata, model, sync_session_maker  # noqa: F401
 
 HERE = Path(__file__).parent
 
@@ -118,10 +118,11 @@ def _gen_test_data_objs():
 
 
 def setup_db_test_data():
+    db_sync_session = sync_session_maker()
     print("Creating test data")
-    with SyncDBSession.begin():
+    with db_sync_session.begin():
         for obj in _gen_test_data_objs():
-            SyncDBSession.add(obj)
+            db_sync_session.add(obj)
 
     print("Caution! Created tenants with deterministic API keys:")
     print("\tadmin:", _gen_test_api_key("admin"))

--- a/duffy/database/setup.py
+++ b/duffy/database/setup.py
@@ -1,4 +1,5 @@
 import sys
+import uuid
 from pathlib import Path
 
 import alembic.command
@@ -8,8 +9,7 @@ from sqlalchemy import inspect
 from ..configuration import config
 
 # Import the DB model here so its classes are considered by metadata.create_all() below.
-from ..database import model  # noqa: F401
-from . import get_sync_engine, metadata
+from . import SyncDBSession, get_sync_engine, metadata, model  # noqa: F401
 
 HERE = Path(__file__).parent
 
@@ -36,3 +36,82 @@ def setup_db_schema():
         cfg.set_main_option("sqlalchemy.url", config["database"]["sqlalchemy"]["sync_url"])
 
         alembic.command.stamp(cfg, "head")
+
+
+def _gen_test_api_key(tenant_name):
+    """Generate deterministic API keys for test users."""
+    return uuid.uuid5(uuid.NAMESPACE_OID, tenant_name)
+
+
+def _gen_test_data_objs():
+    objs = set()
+
+    admin = model.Tenant(
+        name="admin", api_key=_gen_test_api_key("admin"), ssh_key="Boo", is_admin=True
+    )
+    objs.add(admin)
+
+    tenant = model.Tenant(name="tenant", api_key=_gen_test_api_key("tenant"), ssh_key="Boo!")
+    objs.add(tenant)
+
+    chassis = model.Chassis(name="Chassis")
+    objs.add(chassis)
+
+    node_specs = [
+        {
+            "type": "seamicro",
+            "hostname": "node-seamicro-1.example.net",
+            "ipaddr": "192.168.0.11",
+            "chassis": chassis,
+        },
+        {
+            "type": "seamicro",
+            "hostname": "node-seamicro-2.example.net",
+            "ipaddr": "192.168.0.12",
+            "chassis": chassis,
+        },
+    ]
+
+    for quantity, flavour, ipaddrbase in (
+        (40, "small", "192.168.1.10"),
+        (20, "medium", "192.168.2.10"),
+        (10, "large", "192.168.3.10"),
+    ):
+        ipprefix, lastoctetbase = ipaddrbase.rsplit(".", 1)
+        lastoctetbase = int(lastoctetbase)
+        for index in range(1, quantity + 1):
+            lastoctet = lastoctetbase + index
+            node_specs.append(
+                {
+                    "type": "opennebula",
+                    "hostname": f"node-opennebula-{flavour}-{index}.example.net",
+                    "ipaddr": f"{ipprefix}.{lastoctet}",
+                    "flavour": flavour,
+                }
+            )
+
+    for node_spec in node_specs:
+        nodetype = node_spec.pop("type")
+        if nodetype == "opennebula":
+            cls = model.OpenNebulaNode
+        elif nodetype == "seamicro":
+            cls = model.SeaMicroNode
+        else:  # pragma: no cover
+            raise ValueError(f"Unknown node type: {type}")
+
+        node = cls(state="active", **node_spec)
+        objs.add(node)
+
+    return objs
+
+
+def setup_db_test_data():
+    print("Creating test data")
+    with SyncDBSession.begin():
+        for obj in _gen_test_data_objs():
+            SyncDBSession.add(obj)
+
+    print("Caution! Created tenants with deterministic API keys:")
+    print("\tadmin:", _gen_test_api_key("admin"))
+    print("\ttenant:", _gen_test_api_key("tenant"))
+    print("Don't use in production!")

--- a/duffy/database/types.py
+++ b/duffy/database/types.py
@@ -1,0 +1,25 @@
+from .util import DeclEnum
+
+
+class NodeType(str, DeclEnum):
+    virtual = "virtual"
+    physical = "physical"
+    opennebula = "opennebula"
+    seamicro = "seamicro"
+
+
+class NodeState(str, DeclEnum):
+    ready = "ready"
+    active = "active"
+    contextualizing = "contextualizing"
+    deployed = "deployed"
+    deprovisioning = "deprovisioning"
+    done = "done"
+    failing = "failing"
+    failed = "failed"
+
+
+class VirtualNodeFlavour(str, DeclEnum):
+    small = "small"
+    medium = "medium"
+    large = "large"

--- a/duffy/database/util.py
+++ b/duffy/database/util.py
@@ -155,7 +155,7 @@ class RetirableMixin:
         if not value:
             # only set retired_at if previously unset
             if not self.retired_at:
-                self.retired_at = utcnow()
+                self.retired_at = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
         else:
             self.retired_at = None
 

--- a/duffy/shell.py
+++ b/duffy/shell.py
@@ -24,7 +24,7 @@ def get_available_shells():
 
 def get_shell_variables(shell_type: str):
     variables = {
-        "SyncDBSession": database.SyncDBSession,
+        "db_sync_session": database.sync_session_maker(),
         "sqlalchemy": sqlalchemy,
         "select": sqlalchemy.select,
     }
@@ -32,7 +32,7 @@ def get_shell_variables(shell_type: str):
     if shell_type == "ipython" and IPython.InteractiveShell.autoawait:
         # Since IPython 7.0, Python 3.6, you can `await` coroutines in the IPython REPL, so we
         # inject the asynchronous database session object into the namespace of the shell.
-        variables["DBSession"] = database.DBSession
+        variables["db_async_session"] = database.async_session_maker()
 
     # Insert all DB model classes into the local namespace.
     for objname in dir(model):

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -6,5 +6,6 @@ from duffy.app.main import app
 
 @pytest.fixture
 async def client() -> AsyncClient:
+    """A fixture creating an async client for testing the FastAPI app."""
     async with AsyncClient(app=app, base_url="http://duffy-test.example.com") as client:
         yield client

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -1,3 +1,5 @@
+import re
+
 from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
 
 from . import BaseTestController
@@ -13,7 +15,8 @@ class TestSession(BaseTestController):
     }
 
     async def test_create_unknown_tenant(self, client):
+        # setting tenant_id manually will skip the code which would create the tenant
         response = await self._create_obj(client, attrs={"tenant_id": 1})
         assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
         result = response.json()
-        assert "detail" in result
+        assert re.match(r"^can't find tenant with id \d+$", result["detail"])

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -1,10 +1,12 @@
 import re
 import uuid
 
-from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+import pytest
+from sqlalchemy import func, select
+from starlette.status import HTTP_201_CREATED, HTTP_422_UNPROCESSABLE_ENTITY
 
 from duffy.database import DBSession
-from duffy.database.model import Tenant
+from duffy.database.model import Node, PhysicalNode, Tenant, VirtualNode
 
 from . import BaseTestController
 from .test_tenant import TestTenant as _TestTenant
@@ -16,7 +18,10 @@ class TestSession(BaseTestController):
     path = "/api/v1/sessions"
     attrs = {
         "tenant_id": (_TestTenant, "id"),
+        # don't bother with actually allocating nodes here
+        "nodes_specs": [],
     }
+    no_response_attrs = ("nodes_specs",)
 
     async def test_create_unknown_tenant(self, client):
         # setting tenant_id manually will skip the code which would create the tenant
@@ -36,3 +41,89 @@ class TestSession(BaseTestController):
         assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
         result = response.json()
         assert re.match(r"^tenant .* isn't active$", result["detail"])
+
+
+@pytest.mark.usefixtures("db_async_test_data", "db_async_model_initialized")
+@pytest.mark.asyncio
+class TestSessionWorkflow:
+
+    path = "/api/v1/sessions"
+
+    nodes_specs = [
+        {
+            "type": "physical",
+            "quantity": 1,
+            "distro_type": "centos",
+            "distro_version": "8Stream",
+        },
+        {
+            "type": "virtual",
+            "quantity": 2,
+            "flavour": "medium",
+            "distro_type": "fedora",
+            "distro_version": "35",
+        },
+    ]
+
+    @staticmethod
+    async def _get_tenant_obj():
+        return (await DBSession.execute(select(Tenant).filter_by(name="tenant"))).scalar_one()
+
+    @pytest.mark.parametrize("can_reserve", (True, False))
+    async def test_request_session(self, can_reserve, client):
+        tenant = await self._get_tenant_obj()
+
+        if not can_reserve:
+            for node in (await DBSession.execute(select(Node))).scalars():
+                node.state = "deployed"
+            await DBSession.flush()
+
+        request_payload = {"tenant_id": tenant.id, "nodes_specs": self.nodes_specs}
+        response = await client.post(self.path, json=request_payload)
+        result = response.json()
+
+        if can_reserve:
+            assert response.status_code == HTTP_201_CREATED
+
+            # validate nodes have been allocated in the database
+            for nodes_spec in self.nodes_specs:
+                nodes_spec = nodes_spec.copy()
+                quantity = nodes_spec.pop("quantity")
+                nodes_type = nodes_spec.pop("type")
+                if nodes_type == "physical":
+                    nodecls = PhysicalNode
+                elif nodes_type == "virtual":
+                    nodecls = VirtualNode
+                count_result = await DBSession.execute(
+                    select(func.count("id"))
+                    .select_from(nodecls)
+                    .filter_by(state="contextualizing", **nodes_spec)
+                )
+                assert count_result.scalar_one() == quantity
+
+            # validate that the result lists the nodes
+            session = result["session"]
+            nodes = session["nodes"]
+            for nodes_spec in self.nodes_specs:
+                nodes_spec = nodes_spec.copy()
+                quantity = nodes_spec.pop("quantity")
+                matched_nodes_count = 0
+                for node in nodes:
+                    for attr, value in nodes_spec.items():
+                        if attr == "type":
+                            if (
+                                value == "physical"
+                                and node["type"] not in ("physical", "seamicro")
+                                or value == "virtual"
+                                and node["type"] not in ("virtual", "opennebula")
+                            ):
+                                break
+                        elif value != node[attr]:
+                            break
+                    else:
+                        # didn't break out of loop -> matches spec
+                        matched_nodes_count += 1
+                assert matched_nodes_count == quantity
+        else:  # not can_reserve
+            assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
+            assert result["detail"].startswith("can't reserve nodes:")

--- a/tests/app/test_database.py
+++ b/tests/app/test_database.py
@@ -1,0 +1,20 @@
+from unittest import mock
+
+import pytest
+
+from duffy.app.database import req_db_async_session
+
+
+@mock.patch("duffy.app.database.async_session_maker")
+@pytest.mark.asyncio
+async def test_req_db_async_session(async_session_maker):
+    mock_session = mock.MagicMock()
+    mock_session.close = mock.AsyncMock()
+    async_session_maker.return_value = mock_session
+
+    n_iter = 0
+    async for db_async_session in req_db_async_session():
+        n_iter += 1
+        assert db_async_session is mock_session
+    mock_session.close.assert_awaited_with()
+    assert n_iter == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 from duffy.configuration import read_configuration
 from duffy.database import Base, DBSession, SyncDBSession, init_async_model, init_sync_model
+from duffy.database.setup import _gen_test_data_objs
 
 # Configuration fixtures
 
@@ -171,3 +172,25 @@ async def db_async_obj(request, db_async_model_initialized):
         yield obj
 
         await DBSession.rollback()
+
+
+@pytest.fixture
+def db_sync_test_data(db_sync_model_initialized):
+    """A fixture to fill the DB with test data.
+
+    Use this in synchronous tests.
+    """
+    with SyncDBSession.begin():
+        for obj in _gen_test_data_objs():
+            SyncDBSession.add(obj)
+
+
+@pytest.fixture
+async def db_async_test_data(db_async_model_initialized):
+    """A fixture to fill the DB with test data.
+
+    Use this in asynchronous tests.
+    """
+    async with DBSession.begin():
+        for obj in _gen_test_data_objs():
+            DBSession.add(obj)

--- a/tests/database/test_model.py
+++ b/tests/database/test_model.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from duffy.database import DBSession, SyncDBSession, model, types
+from duffy.database import model, types
 
 
 class ModelTestBase:
@@ -16,8 +16,8 @@ class ModelTestBase:
     def test_create_obj(self, db_sync_obj):
         pass
 
-    def test_query_obj_sync(self, db_sync_obj):
-        result = SyncDBSession.execute(select(self.klass))
+    def test_query_obj_sync(self, db_sync_obj, db_sync_session):
+        result = db_sync_session.execute(select(self.klass))
         obj = result.scalar_one()
         for key, value in self.attrs.items():
             if key in self.no_validate_attrs:
@@ -33,7 +33,7 @@ class ModelTestBase:
                 assert objvalue == value
 
     @pytest.mark.asyncio
-    async def test_query_obj_async(self, db_async_obj):
+    async def test_query_obj_async(self, db_async_obj, db_async_session):
         # The selectinload() option tells SQLAlchemy to load related objects and lazy loading breaks
         # things here. See here for details:
         #
@@ -41,7 +41,7 @@ class ModelTestBase:
         #
         # You can specify which relation you're interested in but because this code doesn't know
         # anything about the involved ORM class, we specify that we "want it all".
-        result = await DBSession.execute(select(self.klass).options(selectinload("*")))
+        result = await db_async_session.execute(select(self.klass).options(selectinload("*")))
         obj = result.scalar_one()
         for key, value in self.attrs.items():
             if key in self.no_validate_attrs:

--- a/tests/database/test_model.py
+++ b/tests/database/test_model.py
@@ -5,7 +5,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.orm import selectinload
 
-from duffy.database import DBSession, SyncDBSession, model
+from duffy.database import DBSession, SyncDBSession, model, types
 
 
 class ModelTestBase:
@@ -104,7 +104,7 @@ def _gen_node_attrs(**addl_attrs: Dict[str, Any]) -> dict:
     attrs = {
         "hostname": "lolcathost",
         "ipaddr": "192.0.2.10",  # TEST-NET-1
-        "state": model.NodeState.ready,
+        "state": types.NodeState.ready,
     }
 
     attrs.update(addl_attrs)

--- a/tests/database/test_package.py
+++ b/tests/database/test_package.py
@@ -1,4 +1,3 @@
-from sys import version_info
 from unittest import mock
 
 import pytest
@@ -16,35 +15,32 @@ TEST_CONFIG = {
 
 
 @pytest.mark.duffy_config(TEST_CONFIG)
-@mock.patch("duffy.database.SyncDBSession")
+@mock.patch("duffy.database.sync_session_maker")
 @mock.patch("duffy.database.get_sync_engine")
-def test_init_sync_model(get_sync_engine, SyncDBSession):
+def test_init_sync_model(get_sync_engine, sync_session_maker):
     sentinel = object()
     get_sync_engine.return_value = sentinel
 
     database.init_sync_model()
 
     get_sync_engine.assert_called_once_with()
-    SyncDBSession.remove.assert_called_once_with()
-    SyncDBSession.configure.assert_called_once_with(bind=sentinel)
+    sync_session_maker.configure.assert_called_once_with(bind=sentinel)
 
 
 @pytest.mark.asyncio
 @pytest.mark.duffy_config(TEST_CONFIG)
-@mock.patch("duffy.database.DBSession", new_callable=mock.AsyncMock)
+@mock.patch("duffy.database.async_session_maker", new_callable=mock.AsyncMock)
 @mock.patch("duffy.database.get_async_engine")
-async def test_init_async_model(get_async_engine, DBSession):
+async def test_init_async_model(get_async_engine, async_session_maker):
     sentinel = object()
     get_async_engine.return_value = sentinel
     # configure() is not an async coroutine, avoid warning
-    DBSession.configure = mock.MagicMock()
+    async_session_maker.configure = mock.MagicMock()
 
     await database.init_async_model()
 
     get_async_engine.assert_called_once_with()
-    if version_info >= (3, 8, 0):
-        DBSession.remove.assert_awaited_once_with()
-    DBSession.configure.assert_called_once_with(bind=sentinel)
+    async_session_maker.configure.assert_called_once_with(bind=sentinel)
 
 
 @pytest.mark.asyncio

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 import pytest
 
-from duffy.database import setup
+from duffy.database import model, setup
 
 from ..util import noop_context
 
@@ -53,3 +53,11 @@ def test_setup_db_schema(get_sync_engine, inspect, metadata, Config, stamp, db_e
         engine.begin.assert_not_called()
         metadata.create_all.assert_not_called()
         Config.assert_not_called()
+
+
+@mock.patch("duffy.database.setup.SyncDBSession")
+def test_setup_db_test_data(SyncDBSession):
+    setup.setup_db_test_data()
+    SyncDBSession.begin.assert_called_once_with()
+    for model_cls in (model.Chassis, model.PhysicalNode, model.VirtualNode):
+        assert any(isinstance(call.args[0], model_cls) for call in SyncDBSession.add.call_args_list)

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -55,9 +55,13 @@ def test_setup_db_schema(get_sync_engine, inspect, metadata, Config, stamp, db_e
         Config.assert_not_called()
 
 
-@mock.patch("duffy.database.setup.SyncDBSession")
-def test_setup_db_test_data(SyncDBSession):
+@mock.patch("duffy.database.setup.sync_session_maker")
+def test_setup_db_test_data(sync_session_maker):
+    sync_session_maker.return_value = db_sync_session = mock.MagicMock()
     setup.setup_db_test_data()
-    SyncDBSession.begin.assert_called_once_with()
+    sync_session_maker.assert_called_once_with()
+    db_sync_session.begin.assert_called_once_with()
     for model_cls in (model.Chassis, model.PhysicalNode, model.VirtualNode):
-        assert any(isinstance(call.args[0], model_cls) for call in SyncDBSession.add.call_args_list)
+        assert any(
+            isinstance(call.args[0], model_cls) for call in db_sync_session.add.call_args_list
+        )

--- a/tests/fixtures/test_db_test_data.py
+++ b/tests/fixtures/test_db_test_data.py
@@ -1,0 +1,22 @@
+import pytest
+from sqlalchemy import select
+
+from duffy.database import DBSession, SyncDBSession
+from duffy.database.model import Chassis, Node, Tenant
+
+obj_classes = (Chassis, Node, Tenant)
+
+
+@pytest.mark.parametrize("obj_class", obj_classes)
+def test_objs_sync(obj_class, db_sync_test_data, db_sync_model_initialized):
+    results = SyncDBSession.execute(select(obj_class))
+    objects = results.all()
+    assert objects
+
+
+@pytest.mark.parametrize("obj_class", obj_classes)
+@pytest.mark.asyncio
+async def test_objs_async(obj_class, db_async_test_data, db_async_model_initialized):
+    results = await DBSession.execute(select(obj_class))
+    objects = results.all()
+    assert objects

--- a/tests/fixtures/test_db_test_data.py
+++ b/tests/fixtures/test_db_test_data.py
@@ -1,22 +1,21 @@
 import pytest
 from sqlalchemy import select
 
-from duffy.database import DBSession, SyncDBSession
 from duffy.database.model import Chassis, Node, Tenant
 
 obj_classes = (Chassis, Node, Tenant)
 
 
 @pytest.mark.parametrize("obj_class", obj_classes)
-def test_objs_sync(obj_class, db_sync_test_data, db_sync_model_initialized):
-    results = SyncDBSession.execute(select(obj_class))
+def test_objs_sync(obj_class, db_sync_test_data, db_sync_session):
+    results = db_sync_session.execute(select(obj_class))
     objects = results.all()
     assert objects
 
 
 @pytest.mark.parametrize("obj_class", obj_classes)
 @pytest.mark.asyncio
-async def test_objs_async(obj_class, db_async_test_data, db_async_model_initialized):
-    results = await DBSession.execute(select(obj_class))
+async def test_objs_async(obj_class, db_async_test_data, db_async_session):
+    results = await db_async_session.execute(select(obj_class))
     objects = results.all()
     assert objects

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,28 +108,16 @@ def test_worker(start_worker):
 
 
 @pytest.mark.parametrize(
-    "config_error, parameters",
+    "parameters",
     [
-        (False, parms)
-        for parms in (
-            ("serve",),
-            ("serve", "--host=127.0.0.1"),
-            (f"--config={EXAMPLE_CONFIG.absolute()}", "serve"),
-        )
-    ]
-    + [(True, ("serve",))],
+        ("serve",),
+        ("serve", "--host=127.0.0.1"),
+        (f"--config={EXAMPLE_CONFIG.absolute()}", "serve"),
+    ],
 )
-@mock.patch("duffy.database.init_model")
 @mock.patch("duffy.cli.uvicorn.run")
-def test_serve(uvicorn_run, init_model, config_error, parameters):
-    if config_error:
-        init_model.side_effect = DuffyConfigurationError("database")
+def test_serve(uvicorn_run, parameters):
     runner = CliRunner()
     result = runner.invoke(cli, parameters)
-    init_model.assert_called_once()
-    if not config_error:
-        assert result.exit_code == 0
-        uvicorn_run.assert_called_once()
-    else:
-        assert result.exit_code != 0
-        uvicorn_run.assert_not_called()
+    assert result.exit_code == 0
+    uvicorn_run.assert_called_once()

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,8 +1,10 @@
 from unittest import mock
 
 import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
 
-from duffy import database, exceptions, shell
+from duffy import exceptions, shell
 from duffy.database import model
 
 from .util import noop_context
@@ -33,15 +35,15 @@ def test_get_shell_variables(IPython, with_ipython, with_autoawait):
 
     variables = shell.get_shell_variables("ipython" if with_ipython else "python")
 
-    assert variables["SyncDBSession"] is database.SyncDBSession
+    assert isinstance(variables["db_sync_session"], Session)
     # Do a spot check of one model class.
     assert variables["Tenant"] is model.Tenant
 
     if with_ipython and with_autoawait:
-        assert variables["DBSession"] is database.DBSession
+        assert isinstance(variables["db_async_session"], AsyncSession)
     else:
-        # The asynchronous DBSession must only be made available if the shell does its part.
-        assert "DBSession" not in variables
+        # The asynchronous db_async_session must only be made available if the shell does its part.
+        assert "db_async_session" not in variables
 
 
 @mock.patch("duffy.shell.code")


### PR DESCRIPTION
This implements a good deal of #65: accepting specifications of requested nodes when creating sessions and returning the associated nodes with sessions from the API. It doesn't implement a controller for updating sessions (to let tenants set them inactive) yet, though.

Additionally, implement filling a DB with test data (as test fixtures and an extension to the `setup-db` command) and some refinement to tests.

# How to Test

- Delete the database (file) and perhaps recreate it (PostgreSQL)
- Setup the database and fill it with test data, e.g.:
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)> duffy -c etc/duffy-psql-config.yaml setup-db --test-data
Creating database schema
Setting up database migrations
Creating test data
Caution! Created tenants with deterministic API keys:
	admin: ae6c10d0-0b13-554c-b976-a05d8a18f0cc
	tenant: a8b9899d-b128-59a1-aa86-754920b7f5ed
Don't use in production!
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)>
```
- Verify the test data is there, e.g.:
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)> psql duffy
psql (13.4)
Type "help" for help.

duffy=> select * from nodes;
          created_at           | retired_at | id |    type    |               hostname                
|    ipaddr    | state  | comment | distro_type | distro_version 
-------------------------------+------------+----+------------+---------------------------------------
+--------------+--------+---------+-------------+----------------
 2021-12-21 12:18:22.036233+01 |            |  1 | opennebula | node-opennebula-small-7.example.net   
| 192.168.1.17 | active |         | fedora      | 35
[ ... ]
 2021-12-21 12:18:22.036233+01 |            | 72 | opennebula | node-opennebula-medium-2.example.net  
| 192.168.2.12 | active |         | centos      | 8Stream
(72 rows)

duffy=>
```
- Start the app server
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)> duffy -c etc/duffy-psql-config.yaml serve
 * Starting Duffy...
 * Host address : 127.0.0.1
 * Port number  : 8080
 * Log level    : warning
 * Serving API docs on http://127.0.0.1:8080/docs
```
- Request a session with a certain set of nodes:
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)> http --json post http://localhost:8080/api/v1/sessions tenant_id=2 nodes_specs:='[{"quantity": 1, "type": "physical", "distro_type": "fedora", "distro_version": "35"}, {"quantity": 2, "type": "virtual", "flavour": "medium", "distro_type": "fedora", "distro_version": "35"}]'
HTTP/1.1 201 Created
content-length: 769
content-type: application/json
date: Tue, 21 Dec 2021 12:22:12 GMT
server: uvicorn

{
    "action": "post",
    "session": {
        "active": true,
        "created_at": "2021-12-21T11:22:13.362065+00:00",
        "id": 1,
        "nodes": [
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "hostname": "node-seamicro-2.example.net",
                "ipaddr": "192.168.0.12",
                "type": "seamicro"
            },
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "flavour": "medium",
                "hostname": "node-opennebula-medium-3.example.net",
                "ipaddr": "192.168.2.13",
                "type": "opennebula"
            },
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "flavour": "medium",
                "hostname": "node-opennebula-medium-5.example.net",
                "ipaddr": "192.168.2.15",
                "type": "opennebula"
            }
        ],
        "retired_at": null,
        "tenant": {
            "active": true,
            "created_at": "2021-12-21T11:18:22.036233+00:00",
            "id": 2,
            "is_admin": false,
            "name": "tenant",
            "retired_at": null,
            "ssh_key": "Boo!"
        }
    }
}
```
- Request it again to verify that Duffy refuses to hand out more nodes than are available:
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)> http --json post http://localhost:8080/api/v1/sessions tenant_id=2 nodes_specs:='[{"quantity": 1, "type": "physical", "distro_type": "fedora", "distro_version": "35"}, {"quantity": 2, "type": "virtual", "flavour": "medium", "distro_type": "fedora", "distro_version": "35"}]'
HTTP/1.1 422 Unprocessable Entity
content-length: 122
content-type: application/json
date: Tue, 21 Dec 2021 12:23:16 GMT
server: uvicorn

{
    "detail": "can't reserve nodes: type=<NodeType.physical: 'physical'> quantity=1 distro_type='fedora' distro_version='35'"
}
```
- Release the reserved nodes by setting the `active` flag to `false` (check `active` and `retired_at` in the response):
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--session-workflow)> http --json put http://localhost:8080/api/v1/sessions/1 active:=false
HTTP/1.1 200 OK
content-length: 799
content-type: application/json
date: Tue, 21 Dec 2021 12:25:33 GMT
server: uvicorn

{
    "action": "put",
    "session": {
        "active": false,
        "created_at": "2021-12-21T11:22:13.362065+00:00",
        "id": 1,
        "nodes": [
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "hostname": "node-seamicro-2.example.net",
                "ipaddr": "192.168.0.12",
                "type": "seamicro"
            },
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "flavour": "medium",
                "hostname": "node-opennebula-medium-3.example.net",
                "ipaddr": "192.168.2.13",
                "type": "opennebula"
            },
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "flavour": "medium",
                "hostname": "node-opennebula-medium-5.example.net",
                "ipaddr": "192.168.2.15",
                "type": "opennebula"
            }
        ],
        "retired_at": "2021-12-21T12:25:33.928737+00:00",
        "tenant": {
            "active": true,
            "created_at": "2021-12-21T11:18:22.036233+00:00",
            "id": 2,
            "is_admin": false,
            "name": "tenant",
            "retired_at": null,
            "ssh_key": "Boo!"
        }
    }
}
```
