### PR TITLE
Authenticate API endpoints with HTTP Basic Auth

### DIFF
--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Literal, Union
+from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, conint
 
@@ -59,7 +59,7 @@ class SessionBase(BaseModel, ABC):
 
 
 class SessionCreateModel(SessionBase):
-    tenant_id: int
+    tenant_id: Optional[int]
     nodes_specs: List[Union[PhysicalNodesSpec, VirtualNodesSpec]]
 
 

--- a/duffy/app/auth.py
+++ b/duffy/app/auth.py
@@ -1,0 +1,46 @@
+from fastapi import Depends, HTTPException, Security
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+
+from ..database.model import Tenant
+from .database import req_db_async_session
+
+
+def _req_tenant_factory(optional: bool = False, **kwargs):
+    """Factory creating FastAPI dependencies for authenticating tenants."""
+    if optional:
+        kwargs["auto_error"] = False
+    security = HTTPBasic(realm="duffy", **kwargs)
+
+    async def _req_tenant(
+        db_async_session: AsyncSession = Depends(req_db_async_session),
+        credentials: HTTPBasicCredentials = Security(security),
+    ):
+        if not credentials:
+            if not optional:
+                raise HTTPException(HTTP_403_FORBIDDEN)
+            else:
+                return None
+
+        tenant_name = credentials.username
+        api_key = credentials.password
+
+        tenant = (
+            await db_async_session.execute(select(Tenant).filter_by(name=tenant_name))
+        ).scalar_one_or_none()
+
+        if not tenant or not tenant.validate_api_key(api_key):
+            raise HTTPException(HTTP_401_UNAUTHORIZED)
+
+        if not tenant.active:
+            raise HTTPException(HTTP_403_FORBIDDEN)
+
+        return tenant
+
+    return _req_tenant
+
+
+req_tenant = _req_tenant_factory()
+req_tenant_optional = _req_tenant_factory(optional=True)

--- a/duffy/app/controllers/chassis.py
+++ b/duffy/app/controllers/chassis.py
@@ -6,10 +6,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
-from starlette.status import HTTP_201_CREATED, HTTP_404_NOT_FOUND, HTTP_409_CONFLICT
+from starlette.status import (
+    HTTP_201_CREATED,
+    HTTP_403_FORBIDDEN,
+    HTTP_404_NOT_FOUND,
+    HTTP_409_CONFLICT,
+)
 
 from ...api_models import ChassisCreateModel, ChassisResult, ChassisResultCollection
-from ...database.model import Chassis
+from ...database.model import Chassis, Tenant
+from ..auth import req_tenant
 from ..database import req_db_async_session
 
 router = APIRouter(prefix="/chassis")
@@ -17,7 +23,10 @@ router = APIRouter(prefix="/chassis")
 
 # http get http://localhost:8080/api/v1/chassis
 @router.get("", response_model=ChassisResultCollection, tags=["chassis"])
-async def get_all_chassis(db_async_session: AsyncSession = Depends(req_db_async_session)):
+async def get_all_chassis(
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+    tenant: Tenant = Depends(req_tenant),
+):
     """
     Return all chassis
     """
@@ -29,7 +38,11 @@ async def get_all_chassis(db_async_session: AsyncSession = Depends(req_db_async_
 
 # http get http://localhost:8080/api/v1/chassis/2
 @router.get("/{id}", response_model=ChassisResult, tags=["chassis"])
-async def get_chassis(id: int, db_async_session: AsyncSession = Depends(req_db_async_session)):
+async def get_chassis(
+    id: int,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+    tenant: Tenant = Depends(req_tenant),
+):
     """
     Return the chassis with the specified **ID**
     """
@@ -49,10 +62,14 @@ async def get_chassis(id: int, db_async_session: AsyncSession = Depends(req_db_a
 async def create_chassis(
     data: ChassisCreateModel,
     db_async_session: AsyncSession = Depends(req_db_async_session),
+    tenant: Tenant = Depends(req_tenant),
 ):
     """
     Create a chassis with the specified **name** and optional **description**
     """
+    if not tenant.is_admin:
+        raise HTTPException(HTTP_403_FORBIDDEN)
+
     chassis = Chassis(name=data.name, description=data.description)
 
     db_async_session.add(chassis)
@@ -66,10 +83,17 @@ async def create_chassis(
 
 # http delete http://localhost:8080/api/v1/chassis/2
 @router.delete("/{id}", response_model=ChassisResult, tags=["chassis"])
-async def delete_chassis(id: int, db_async_session: AsyncSession = Depends(req_db_async_session)):
+async def delete_chassis(
+    id: int,
+    db_async_session: AsyncSession = Depends(req_db_async_session),
+    tenant: Tenant = Depends(req_tenant),
+):
     """
     Delete the chassis with the specified **ID**
     """
+    if not tenant.is_admin:
+        raise HTTPException(HTTP_403_FORBIDDEN)
+
     chassis = (
         await db_async_session.execute(select(Chassis).filter_by(id=id))
     ).scalar_one_or_none()

--- a/tests/app/conftest.py
+++ b/tests/app/conftest.py
@@ -1,11 +1,111 @@
+from typing import Iterator
+
 import pytest
 from httpx import AsyncClient
+from sqlalchemy import select
 
 from duffy.app.main import app
+from duffy.database.model import Tenant
+from duffy.database.setup import _gen_test_api_key
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "client_auth_as")
+    config.addinivalue_line("markers", "auth_tenant")
 
 
 @pytest.fixture
-async def client() -> AsyncClient:
-    """A fixture creating an async client for testing the FastAPI app."""
-    async with AsyncClient(app=app, base_url="http://duffy-test.example.com") as client:
+async def auth_admin(db_async_session) -> Iterator[Tenant]:
+    """A fixture creating an admin tenant with a deterministic API key.
+
+    The API key will be set deterministically, depending on the name of
+    the tenant ('admin'): ae6c10d0-0b13-554c-b976-a05d8a18f0cc
+    """
+    async with db_async_session.begin():
+        admin = (
+            await db_async_session.execute(select(Tenant).filter_by(name="admin"))
+        ).scalar_one_or_none()
+        if not admin:
+            admin = Tenant(
+                name="admin",
+                is_admin=True,
+                ssh_key="<ssh-key>",
+                api_key=_gen_test_api_key("admin"),
+            )
+            db_async_session.add(admin)
+            await db_async_session.flush()
+        else:
+            # Tenant of the same name exists (probably because the DB is filld with test data).
+            # Ensure that its API key and active attribute are valid.
+            admin.api_key = _gen_test_api_key("admin")
+
+    yield admin
+
+
+@pytest.fixture
+async def auth_tenant(request: pytest.FixtureRequest, db_async_session) -> Iterator[Tenant]:
+    """A fixture creating a tenant with a deterministic API key.
+
+    Use pytest.mark.auth_tenant(active=...) to specify whether the tenant should
+    be active or not.
+
+    The API key will be set deterministically, depending on the name of
+    the tenant ('tenant'): a8b9899d-b128-59a1-aa86-754920b7f5ed
+    """
+    active = True
+    for node in request.node.listchain():
+        for marker in node.own_markers:
+            if marker.name == "auth_tenant":
+                active = marker.kwargs.get("active", active)
+
+    async with db_async_session.begin():
+        tenant = (
+            await db_async_session.execute(select(Tenant).filter_by(name="tenant"))
+        ).scalar_one_or_none()
+        if not tenant:
+            tenant = Tenant(
+                name="tenant",
+                is_admin=False,
+                active=active,
+                ssh_key="<ssh-key>",
+                api_key=_gen_test_api_key("tenant"),
+            )
+            db_async_session.add(tenant)
+            await db_async_session.flush()
+        else:
+            # Tenant of the same name exists (probably because the DB is filld with test data).
+            # Ensure that its API key and active attribute are valid.
+            tenant.api_key = _gen_test_api_key("tenant")
+            tenant.active = active
+
+    yield tenant
+
+
+@pytest.fixture
+async def client(
+    request: pytest.FixtureRequest, auth_admin: Tenant, auth_tenant: Tenant
+) -> Iterator[AsyncClient]:
+    """A fixture creating an async client for testing the FastAPI app.
+
+    This client will attempt to make authenticated API requests using
+    the `auth_tenant` fixture."""
+    auth = (auth_tenant.name, str(_gen_test_api_key(auth_tenant.name)))
+
+    for node in request.node.listchain():
+        for marker in node.own_markers:
+            if marker.name == "client_auth_as":
+                if not marker.args or marker.args[0] is None:
+                    auth = None
+                elif len(marker.args) > 1:
+                    raise ValueError("client takes no more than one argument")
+                else:
+                    name = marker.args[0]
+                    for auth_obj in (auth_admin, auth_tenant):
+                        if name == auth_obj.name:
+                            auth = (auth_obj.name, str(_gen_test_api_key(auth_obj.name)))
+                            break
+                    else:
+                        raise ValueError(f"can't create client for tenant with name '{name}'")
+
+    async with AsyncClient(app=app, base_url="http://duffy-test.example.com", auth=auth) as client:
         yield client

--- a/tests/app/controllers/__init__.py
+++ b/tests/app/controllers/__init__.py
@@ -6,8 +6,12 @@ from starlette.status import HTTP_200_OK, HTTP_201_CREATED, HTTP_404_NOT_FOUND, 
 
 @pytest.mark.asyncio
 @pytest.mark.usefixtures(
-    "db_sync_schema", "db_sync_model_initialized", "db_async_schema", "db_async_model_initialized"
+    "db_sync_schema",
+    "db_sync_model_initialized",
+    "db_async_schema",
+    "db_async_model_initialized",
 )
+@pytest.mark.client_auth_as("admin")
 class BaseTestController:
     """A class testing controllers.
 
@@ -104,9 +108,6 @@ class BaseTestController:
             attrs = cls.attrs
         if not no_response_attrs:
             no_response_attrs = cls.no_response_attrs
-        # The `id` attribute of any created object must be 1 because no objects exist in the
-        # database before running this test, the `db_*_model_initialized` fixtures take care of it.
-        assert item["id"] == 1
         for key, value in attrs.items():
             if key in no_response_attrs:
                 continue
@@ -175,8 +176,11 @@ class BaseTestController:
         """Test that an object can be retrieved via the API endpoint."""
         if testcase != "not found":
             create_response = await self._create_obj(client)
+            obj_id = create_response.json()[self.name]["id"]
+        else:
+            obj_id = -1
 
-        response = await client.get(f"{self.path}/1")
+        response = await client.get(f"{self.path}/{obj_id}")
 
         if testcase == "found":
             assert response.status_code == HTTP_200_OK
@@ -193,17 +197,21 @@ class BaseTestController:
         response = await client.get(self.path)
         result = response.json()
         assert self.name_plural in result
-        obj = result[self.name_plural][0]
-        assert obj["id"] == 1
+        objs = result[self.name_plural]
+        obj = objs[-1]
+        assert obj["id"] == len(objs)
         attrs = {**self.attrs, **self._add_attrs_from_response(create_response)}
         self._verify_item(obj, attrs=attrs)
 
     @pytest.mark.parametrize("testcase", ("found", "not found"))
     async def test_delete_obj(self, client, testcase):
         if testcase != "not found":
-            await self._create_obj(client)
+            create_response = await self._create_obj(client)
+            obj_id = create_response.json()[self.name]["id"]
+        else:
+            obj_id = -1
 
-        response = await client.delete(f"{self.path}/1")
+        response = await client.delete(f"{self.path}/{obj_id}")
 
         if testcase == "found":
             assert response.status_code == HTTP_200_OK

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, select
 from starlette.status import (
     HTTP_200_OK,
     HTTP_201_CREATED,
+    HTTP_403_FORBIDDEN,
     HTTP_404_NOT_FOUND,
     HTTP_422_UNPROCESSABLE_ENTITY,
 )
@@ -13,7 +14,6 @@ from starlette.status import (
 from duffy.database.model import Node, PhysicalNode, Session, Tenant, VirtualNode
 
 from . import BaseTestController
-from .test_tenant import TestTenant as _TestTenant
 
 
 class TestSession(BaseTestController):
@@ -21,11 +21,31 @@ class TestSession(BaseTestController):
     name = "session"
     path = "/api/v1/sessions"
     attrs = {
-        "tenant_id": (_TestTenant, "id"),
         # don't bother with actually allocating nodes here
         "nodes_specs": [],
     }
     no_response_attrs = ("nodes_specs",)
+    create_unprivileged = True
+
+    @staticmethod
+    async def _create_tenant(db_async_session, **kwargs):
+        for key, value in {
+            "name": "Other User",
+            "api_key": uuid.uuid4(),
+            "ssh_key": "<ssh key>",
+        }.items():
+            kwargs.setdefault(key, value)
+        tenant = Tenant(**kwargs)
+        db_async_session.add(tenant)
+        await db_async_session.flush()
+        return tenant
+
+    async def test_create_other_tenant(self, client, db_async_session, auth_tenant):
+        other_tenant = await self._create_tenant(db_async_session)
+        response = await self._create_obj(client, attrs={"tenant_id": other_tenant.id})
+        assert response.status_code == HTTP_201_CREATED
+        result = response.json()
+        assert result["session"]["tenant"]["id"] == other_tenant.id
 
     async def test_create_unknown_tenant(self, client, auth_tenant):
         response = await self._create_obj(client, attrs={"tenant_id": auth_tenant.id + 1})
@@ -34,16 +54,42 @@ class TestSession(BaseTestController):
         assert re.match(r"^can't find tenant with id \d+$", result["detail"])
 
     async def test_create_retired_tenant(self, client, db_async_session):
-        # Create the tenant manually and set it as retired
-        tenant = Tenant(name="Happily retired", active=False, api_key=uuid.uuid4(), ssh_key="BOO")
-        db_async_session.add(tenant)
-        await db_async_session.flush()
+        retired_tenant = await self._create_tenant(
+            db_async_session, name="Happily retired", active=False
+        )
 
-        response = await self._create_obj(client, attrs={"tenant_id": tenant.id})
+        response = await self._create_obj(client, attrs={"tenant_id": retired_tenant.id})
 
         assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
         result = response.json()
         assert re.match(r"^tenant .* isn't active$", result["detail"])
+
+    @pytest.mark.client_auth_as("tenant")
+    async def test_retrieve_obj_other_tenant(self, client, db_async_session):
+        other_tenant = await self._create_tenant(db_async_session)
+        session = Session(tenant=other_tenant)
+        db_async_session.add(session)
+        await db_async_session.flush()
+
+        response = await client.get(f"{self.path}/{session.id}")
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+    @pytest.mark.client_auth_as("tenant")
+    async def test_retrieve_collection_filtered(self, client, db_async_session, auth_tenant):
+        other_tenant = await self._create_tenant(db_async_session)
+
+        # Create a couple of sessions, some of them owned by the authenticated tenant, some others
+        # by someone else.
+        for i in range(10):
+            tenant = auth_tenant if i % 2 else other_tenant
+            # Use tenant_id here because the auth_tenant object belongs to another session, the one
+            # used in its fixture.
+            db_async_session.add(Session(tenant_id=tenant.id))
+        await db_async_session.flush()
+
+        response = await client.get(self.path)
+        result = response.json()
+        assert all(session["tenant"]["id"] == auth_tenant.id for session in result["sessions"])
 
 
 @pytest.mark.usefixtures("db_async_test_data", "db_async_model_initialized")
@@ -68,18 +114,28 @@ class TestSessionWorkflow:
         },
     ]
 
-    @pytest.mark.parametrize("can_reserve", (True, False))
-    async def test_request_session(self, can_reserve, client, db_async_session, auth_tenant):
-        if not can_reserve:
+    @pytest.mark.parametrize(
+        "testcase",
+        (
+            "normal",
+            pytest.param("inactive tenant", marks=pytest.mark.auth_tenant(active=False)),
+            "insufficient nodes",
+            "wrong tenant",
+        ),
+    )
+    async def test_request_session(self, testcase, client, db_async_session, auth_tenant):
+        if testcase == "insufficient nodes":
             for node in (await db_async_session.execute(select(Node))).scalars():
                 node.state = "deployed"
-            await db_async_session.flush()
+            await db_async_session.commit()
 
-        request_payload = {"tenant_id": auth_tenant.id, "nodes_specs": self.nodes_specs}
+        request_payload = {"nodes_specs": self.nodes_specs}
+        if testcase == "wrong tenant":
+            request_payload["tenant_id"] = auth_tenant.id + 1
         response = await client.post(self.path, json=request_payload)
         result = response.json()
 
-        if can_reserve:
+        if testcase == "normal":
             assert response.status_code == HTTP_201_CREATED
 
             # validate nodes have been allocated in the database
@@ -121,14 +177,21 @@ class TestSessionWorkflow:
                         # didn't break out of loop -> matches spec
                         matched_nodes_count += 1
                 assert matched_nodes_count == quantity
-        else:  # not can_reserve
+        elif testcase == "inactive tenant":
+            assert response.status_code == HTTP_403_FORBIDDEN
+        elif testcase == "insufficient nodes":
             assert response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
             assert result["detail"].startswith("can't reserve nodes:")
+        else:  # testcase == "wrong tenant"
+            assert response.status_code == HTTP_403_FORBIDDEN
+            assert result["detail"] == "can't create session for other tenant"
 
-    @pytest.mark.parametrize("testcase", ("normal", "unknown-session", "retired-session"))
+    @pytest.mark.parametrize(
+        "testcase", ("normal", "unknown-session", "retired-session", "unauthorized")
+    )
     async def test_update_session(self, testcase, client, db_async_session, auth_tenant):
         if testcase != "unknown-session":
-            request_payload = {"tenant_id": auth_tenant.id, "nodes_specs": self.nodes_specs}
+            request_payload = {"nodes_specs": self.nodes_specs}
             create_response = await client.post(self.path, json=request_payload)
             create_result = create_response.json()
             created_session = create_result["session"]
@@ -138,11 +201,21 @@ class TestSessionWorkflow:
             assert created_session["retired_at"] is None
 
             if testcase == "retired-session":
-                retired_session = (
-                    await db_async_session.execute(select(Session).filter_by(id=session_id))
-                ).scalar_one()
-                retired_session.active = False
-                await db_async_session.flush()
+                async with db_async_session.begin():
+                    retired_session = (
+                        await db_async_session.execute(select(Session).filter_by(id=session_id))
+                    ).scalar_one()
+                    retired_session.active = False
+            elif testcase == "unauthorized":
+                # make the session be owned by the admin tenant
+                async with db_async_session.begin():
+                    admin_tenant = (
+                        await db_async_session.execute(select(Tenant).filter_by(name="admin"))
+                    ).scalar_one()
+                    session = (
+                        await db_async_session.execute(select(Session).filter_by(id=session_id))
+                    ).scalar_one()
+                    session.tenant = admin_tenant
         else:
             session_id = 1
 
@@ -156,6 +229,8 @@ class TestSessionWorkflow:
             assert updated_session["retired_at"] is not None
         elif testcase == "unknown-session":
             assert update_response.status_code == HTTP_404_NOT_FOUND
+        elif testcase == "unauthorized":
+            assert update_response.status_code == HTTP_403_FORBIDDEN
         else:  # testcase == "retired-session"
             assert update_response.status_code == HTTP_422_UNPROCESSABLE_ENTITY
             assert re.match(r"^session .* is retired$", update_result["detail"])

--- a/tests/app/controllers/test_tenant.py
+++ b/tests/app/controllers/test_tenant.py
@@ -1,6 +1,9 @@
-from uuid import uuid4
+import uuid
 
-from starlette.status import HTTP_201_CREATED
+import pytest
+from starlette.status import HTTP_201_CREATED, HTTP_403_FORBIDDEN
+
+from duffy.database.setup import _gen_test_api_key
 
 from . import BaseTestController
 
@@ -11,7 +14,7 @@ class TestTenant(BaseTestController):
     path = "/api/v1/tenants"
     attrs = {
         "name": "Some Honky Tenant!",
-        "api_key": str(uuid4()),
+        "api_key": str(uuid.uuid4()),
         "ssh_key": "With a honky SSH key!",
     }
     no_response_attrs = ("api_key",)
@@ -22,3 +25,25 @@ class TestTenant(BaseTestController):
         assert response.status_code == HTTP_201_CREATED
         result = response.json()
         self._verify_item(result[self.name])
+
+    @pytest.mark.client_auth_as("tenant")
+    async def test_retrieve_obj_other_tenant(self, client, auth_admin):
+        other_tenant_response = await self._create_obj(
+            client,
+            attrs={"name": "Another Tenant"},
+            client_kwargs={"auth": (auth_admin.name, str(_gen_test_api_key(auth_admin.name)))},
+        )
+        other_tenant_id = other_tenant_response.json()["tenant"]["id"]
+        response = await client.get(f"{self.path}/{other_tenant_id}")
+        assert response.status_code == HTTP_403_FORBIDDEN
+
+    @pytest.mark.client_auth_as("tenant")
+    async def test_retrieve_collection_filtered(self, client, auth_admin, auth_tenant):
+        await self._create_obj(
+            client,
+            attrs={"name": "Another Tenant"},
+            client_kwargs={"auth": (auth_admin.name, str(_gen_test_api_key(auth_admin.name)))},
+        )
+        response = await client.get(self.path)
+        result = response.json()
+        assert all(tenant["id"] == auth_tenant.id for tenant in result["tenants"])

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -1,0 +1,75 @@
+from unittest import mock
+
+import pytest
+from fastapi.exceptions import HTTPException
+from sqlalchemy import select
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
+
+from duffy.app.auth import _req_tenant_factory
+from duffy.database.model import Tenant
+from duffy.database.setup import _gen_test_api_key
+
+from ..util import noop_context
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    (
+        "authenticated",
+        "unauthenticated",
+        "unauthenticated-optional",
+        "authenticated-unknown",
+        "authenticated-retired",
+    ),
+)
+@pytest.mark.asyncio
+async def test__req_tenant_factory(testcase, db_async_session, db_async_test_data):
+    if "unauthenticated" in testcase:
+        credentials = None
+    else:
+        credentials = mock.MagicMock()
+        if "unknown" not in testcase:
+            credentials.username = "tenant"
+            api_key = _gen_test_api_key("tenant")
+            credentials.password = str(api_key)
+        else:
+            credentials.username = "BOOP"
+            credentials.password = "FOO"
+
+    if "retired" in testcase:
+        for db_tenant in (
+            await db_async_session.execute(select(Tenant).filter_by(name=credentials.username))
+        ).scalars():
+            db_tenant.active = False
+        await db_async_session.flush()
+
+    if "unauthenticated" in testcase and "optional" not in testcase:
+        expectation = pytest.raises(HTTPException)
+        exception_args = (HTTP_403_FORBIDDEN,)
+    elif "unauthenticated" not in testcase and "unknown" in testcase:
+        expectation = pytest.raises(HTTPException)
+        exception_args = (HTTP_401_UNAUTHORIZED,)
+    elif "unauthenticated" not in testcase and "retired" in testcase:
+        expectation = pytest.raises(HTTPException)
+        exception_args = (HTTP_403_FORBIDDEN,)
+    else:
+        expectation = noop_context()
+        exception_args = None
+
+    get_req_tenant = _req_tenant_factory(optional="optional" in testcase)
+
+    with expectation as excinfo:
+        tenant = await get_req_tenant(db_async_session=db_async_session, credentials=credentials)
+
+    if exception_args:
+        assert excinfo.value.args == exception_args
+    else:
+        if "unauthenticated" not in testcase:
+            assert tenant
+            assert tenant.active
+            assert tenant.name == credentials.username
+            assert tenant.validate_api_key(api_key)
+        else:
+            # ensure not testcase is overlooked
+            assert "optional" in testcase
+            assert tenant is None

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -9,6 +9,7 @@ from duffy.exceptions import DuffyConfigurationError
 from ..util import noop_context
 
 
+@pytest.mark.client_auth_as(None)
 @pytest.mark.asyncio
 class TestMain:
     api_paths = (


### PR DESCRIPTION
Fixes: #158

This is based on PR #152 and adds HTTP Basic authentication to all functional API endpoints.

# How to test

- As ever, delete the database and if applicable (PostgreSQL), recreate it.
- Setup the DB schema and fill it with test data.
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> duffy -c etc/duffy-config.yaml setup-db --test-data
Creating database schema
Setting up database migrations
Creating test data
Caution! Created tenants with deterministic API keys:
	admin: ae6c10d0-0b13-554c-b976-a05d8a18f0cc
	tenant: a8b9899d-b128-59a1-aa86-754920b7f5ed
Don't use in production!
```
- Run the app server in its own shell.
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> duffy -c etc/duffy-config.yaml serve
 * Starting Duffy...
 * Host address : 127.0.0.1
 * Port number  : 8080
 * Log level    : warning
 * Serving API docs on http://127.0.0.1:8080/docs
```
- Query tenants (from here on in another shell).
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth admin:ae6c10d0-0b13-554c-b976-a05d8a18f0cc get http://localhost:8080/api/v1/tenants
HTTP/1.1 200 OK
content-length: 289
content-type: application/json
date: Wed, 22 Dec 2021 21:35:16 GMT
server: uvicorn

{
    "action": "get",
    "tenants": [
        {
            "active": true,
            "created_at": "2021-12-22T21:28:58+00:00",
            "id": 1,
            "is_admin": false,
            "name": "tenant",
            "retired_at": null,
            "ssh_key": "Boo!"
        },
        {
            "active": true,
            "created_at": "2021-12-22T21:28:58+00:00",
            "id": 2,
            "is_admin": true,
            "name": "admin",
            "retired_at": null,
            "ssh_key": "Boo"
        }
    ]
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth tenant:a8b9899d-b128-59a1-aa86-754920b7f5ed get http://localhost:8080/api/v1/tenants
HTTP/1.1 200 OK
content-length: 160
content-type: application/json
date: Wed, 22 Dec 2021 21:35:33 GMT
server: uvicorn

{
    "action": "get",
    "tenants": [
        {
            "active": true,
            "created_at": "2021-12-22T21:28:58+00:00",
            "id": 1,
            "is_admin": false,
            "name": "tenant",
            "retired_at": null,
            "ssh_key": "Boo!"
        }
    ]
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)>
```
- Provoke some authentication errors.
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http get http://localhost:8080/api/v1/tenants
HTTP/1.1 401 Unauthorized
content-length: 30
content-type: application/json
date: Wed, 22 Dec 2021 21:36:48 GMT
server: uvicorn
www-authenticate: Basic realm="duffy"

{
    "detail": "Not authenticated"
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth tenant:7e57e2d4-bacf-4362-973e-c47594dbbeae get http://localhost:8080/api/v1/tenants
HTTP/1.1 401 Unauthorized
content-length: 25
content-type: application/json
date: Wed, 22 Dec 2021 21:37:42 GMT
server: uvicorn

{
    "detail": "Unauthorized"
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth nosuchtenant:a8b9899d-b128-59a1-aa86-754920b7f5ed get http://localhost:8080/api/v1/tenants
HTTP/1.1 401 Unauthorized
content-length: 25
content-type: application/json
date: Wed, 22 Dec 2021 21:38:09 GMT
server: uvicorn

{
    "detail": "Unauthorized"
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)>
```
- Verify that `admin` can e.g. create sessions for others (see tenant ids from above)…
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth admin:ae6c10d0-0b13-554c-b976-a05d8a18f0cc --json post http://localhost:8080/api/v1/sessions tenant_id:=1 nodes_specs:='[{"quantity": 1, "type": "physical", "distro_type": "fedora", "distro_version": "35"}, {"quantity": 2, "type": "virtual", "flavour": "medium", "distro_type": "fedora", "distro_version": "35"}]'
HTTP/1.1 201 Created
content-length: 755
content-type: application/json
date: Wed, 22 Dec 2021 21:42:46 GMT
server: uvicorn

{
    "action": "post",
    "session": {
        "active": true,
        "created_at": "2021-12-22T21:42:46+00:00",
        "id": 1,
        "nodes": [
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "flavour": "medium",
                "hostname": "node-opennebula-medium-1.example.net",
                "ipaddr": "192.168.2.11",
                "type": "opennebula"
            },
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "hostname": "node-seamicro-2.example.net",
                "ipaddr": "192.168.0.12",
                "type": "seamicro"
            },
            {
                "comment": null,
                "distro_type": "fedora",
                "distro_version": "35",
                "flavour": "medium",
                "hostname": "node-opennebula-medium-3.example.net",
                "ipaddr": "192.168.2.13",
                "type": "opennebula"
            }
        ],
        "retired_at": null,
        "tenant": {
            "active": true,
            "created_at": "2021-12-22T21:28:58+00:00",
            "id": 1,
            "is_admin": false,
            "name": "tenant",
            "retired_at": null,
            "ssh_key": "Boo!"
        }
    }
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)>
```
- …but of course not the other way around.
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth tenant:a8b9899d-b128-59a1-aa86-754920b7f5ed --json post http://localhost:8080/api/v1/sessions tenant_id:=2 nodes_specs:='[{"quantity": 1, "type": "physical", "distro_type": "fedora", "distro_version": "35"}, {"quantity": 2, "type": "virtual", "flavour": "medium", "distro_type": "fedora", "distro_version": "35"}]'
HTTP/1.1 403 Forbidden
content-length: 50
content-type: application/json
date: Wed, 22 Dec 2021 21:44:23 GMT
server: uvicorn

{
    "detail": "can't create session for other tenant"
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)>
```
- Verify a normal tenant can't delete even e.g. their own session…
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)> http --auth tenant:a8b9899d-b128-59a1-aa86-754920b7f5ed delete http://localhost:8080/api/v1/sessions/1
HTTP/1.1 403 Forbidden
content-length: 22
content-type: application/json
date: Wed, 22 Dec 2021 21:47:41 GMT
server: uvicorn

{
    "detail": "Forbidden"
}


(duffy) nils@makake:~/src/fedora-infra/duffy (dev--auth-endpoints)>
```
- …however, `admin` could – if only we had set up proper deletion cascades on the relationship from `Session` ⇒ `SessionNode` :wink:. That isn't part of this PR, and maybe we should get rid of the DELETE endpoints entirely, as we seem to want to keep around all objects in the database, but that's a different discussion.