### PR TITLE
Create tenants with random API keys

### DIFF
--- a/duffy/api_models/__init__.py
+++ b/duffy/api_models/__init__.py
@@ -31,6 +31,7 @@ from .session import (  # noqa: F401
 )
 from .tenant import (  # noqa: F401
     TenantCreateModel,
+    TenantCreateResult,
     TenantModel,
     TenantResult,
     TenantResultCollection,

--- a/duffy/api_models/__init__.py
+++ b/duffy/api_models/__init__.py
@@ -32,6 +32,7 @@ from .session import (  # noqa: F401
 from .tenant import (  # noqa: F401
     TenantCreateModel,
     TenantCreateResult,
+    TenantCreateResultModel,
     TenantModel,
     TenantResult,
     TenantResultCollection,

--- a/duffy/api_models/tenant.py
+++ b/duffy/api_models/tenant.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import List, Optional
 
-from pydantic import UUID4, BaseModel
+from pydantic import UUID4, BaseModel, SecretStr
 
 from .common import APIResult, CreatableMixin, RetirableMixin
 
@@ -11,7 +11,7 @@ from .common import APIResult, CreatableMixin, RetirableMixin
 class TenantBase(BaseModel, ABC):
     name: str
     is_admin: Optional[bool]
-    ssh_key: str
+    ssh_key: SecretStr
 
     class Config:
         orm_mode = True
@@ -30,6 +30,11 @@ class TenantModel(TenantBase, CreatableMixin, RetirableMixin):
 
 class TenantResult(APIResult):
     tenant: TenantModel
+
+
+class TenantCreateResult(TenantResult):
+    class Config:
+        json_encoders = {SecretStr: lambda v: v.get_secret_value() if v else None}
 
 
 class TenantResultCollection(APIResult):

--- a/duffy/api_models/tenant.py
+++ b/duffy/api_models/tenant.py
@@ -18,11 +18,15 @@ class TenantBase(BaseModel, ABC):
 
 
 class TenantCreateModel(TenantBase):
-    api_key: UUID4
+    pass
 
 
 class TenantModel(TenantBase, CreatableMixin, RetirableMixin):
     id: int
+
+
+class TenantCreateResultModel(TenantModel):
+    api_key: UUID4
 
 
 # API results
@@ -33,6 +37,8 @@ class TenantResult(APIResult):
 
 
 class TenantCreateResult(TenantResult):
+    tenant: TenantCreateResultModel
+
     class Config:
         json_encoders = {SecretStr: lambda v: v.get_secret_value() if v else None}
 

--- a/duffy/app/controllers/tenant.py
+++ b/duffy/app/controllers/tenant.py
@@ -13,7 +13,12 @@ from starlette.status import (
     HTTP_409_CONFLICT,
 )
 
-from ...api_models import TenantCreateModel, TenantResult, TenantResultCollection
+from ...api_models import (
+    TenantCreateModel,
+    TenantCreateResult,
+    TenantResult,
+    TenantResultCollection,
+)
 from ...database.model import Tenant
 from ..auth import req_tenant
 from ..database import req_db_async_session
@@ -62,7 +67,7 @@ async def get_tenant(
 
 
 # http --json post http://localhost:8080/api/v1/tenants name="Unique name"
-@router.post("", status_code=HTTP_201_CREATED, response_model=TenantResult, tags=["tenants"])
+@router.post("", status_code=HTTP_201_CREATED, response_model=TenantCreateResult, tags=["tenants"])
 async def create_tenant(
     data: TenantCreateModel,
     db_async_session: AsyncSession = Depends(req_db_async_session),
@@ -75,7 +80,10 @@ async def create_tenant(
         raise HTTPException(HTTP_403_FORBIDDEN)
 
     created_tenant = Tenant(
-        name=data.name, is_admin=data.is_admin, api_key=data.api_key, ssh_key=data.ssh_key
+        name=data.name,
+        is_admin=data.is_admin,
+        api_key=data.api_key,
+        ssh_key=data.ssh_key.get_secret_value(),
     )
     db_async_session.add(created_tenant)
     try:

--- a/tests/app/controllers/__init__.py
+++ b/tests/app/controllers/__init__.py
@@ -30,9 +30,11 @@ class BaseTestController:
                 the API. Values can be tuples of other controller test
                 classes and an item name to create such objects and use
                 the respective items in the result.
-        no_response_attrs:
-                A sequence of attribute names which are not returned in
-                a response from the API endpoint.
+        no_verify_attrs:
+                A sequence of attribute names which should not be
+                checked, e.g. because they are not returned in a
+                response from the API endpoint or are expected to
+                differ.
         unique: Whether or not objects with the same attributes can
                 exist more than once. If it is a string, check whether
                 it is in the error detail (case-insensitively). If it is
@@ -81,7 +83,7 @@ class BaseTestController:
     name = None
     path = None
     attrs = {}
-    no_response_attrs = ()
+    no_verify_attrs = ()
     unique = False
     create_unprivileged = False
 
@@ -132,13 +134,13 @@ class BaseTestController:
         return response
 
     @classmethod
-    def _verify_item(cls, item, attrs=None, no_response_attrs=None):
+    def _verify_item(cls, item, attrs=None, no_verify_attrs=None):
         if not attrs:
             attrs = cls.attrs
-        if not no_response_attrs:
-            no_response_attrs = cls.no_response_attrs
+        if not no_verify_attrs:
+            no_verify_attrs = cls.no_verify_attrs
         for key, value in attrs.items():
-            if key in no_response_attrs:
+            if key in no_verify_attrs:
                 continue
             try:
                 subcls, _ = cls.attrs[key]
@@ -180,7 +182,7 @@ class BaseTestController:
 
         retval = {}
         for name, value in cls.attrs.items():
-            if name in cls.no_response_attrs:
+            if name in cls.no_verify_attrs:
                 continue
             try:
                 subcls, item = value

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -24,7 +24,7 @@ class TestSession(BaseTestController):
         # don't bother with actually allocating nodes here
         "nodes_specs": [],
     }
-    no_response_attrs = ("nodes_specs",)
+    no_verify_attrs = ("nodes_specs",)
     create_unprivileged = True
 
     @staticmethod

--- a/tests/app/controllers/test_tenant.py
+++ b/tests/app/controllers/test_tenant.py
@@ -17,7 +17,7 @@ class TestTenant(BaseTestController):
         "api_key": str(uuid.uuid4()),
         "ssh_key": "With a honky SSH key!",
     }
-    no_response_attrs = ("api_key",)
+    no_verify_attrs = ("api_key", "ssh_key")
     unique = "unique"
 
     async def test_with_is_admin_set(self, client):


### PR DESCRIPTION
Additionally, don't expose tenants’ SSH keys in API responses except the one where they are created.

Fixes: #157

# How to test

- Basic setup with test data, yadda yadda. :grinning: 
- Start the app server.
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--random-api-key)> duffy -c etc/duffy-config.yaml serve
 * Starting Duffy...
 * Host address : 127.0.0.1
 * Port number  : 8080
 * Log level    : warning
 * Serving API docs on http://127.0.0.1:8080/docs
```
- Create a new tenant, take note of its generated `api_key`.
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--random-api-key)> http --auth admin:ae6c10d0-0b13-554c-b976-a05d8a18f0cc post http://localhost:8080/api/v1/tenants name=the-new-tenant ssh_key=what-a-key
HTTP/1.1 201 Created
content-length: 221
content-type: application/json
date: Thu, 23 Dec 2021 15:31:08 GMT
server: uvicorn

{
    "action": "post",
    "tenant": {
        "active": true,
        "api_key": "f294a2a7-4225-4115-b352-613459c41c7e",
        "created_at": "2021-12-23T15:31:09+00:00",
        "id": 4,
        "is_admin": false,
        "name": "the-new-tenant",
        "retired_at": null,
        "ssh_key": "what-a-key"
    }
}
```
- Attempt to authenticate to the API using the new tenant's credentials
```
(duffy) nils@makake:~/src/fedora-infra/duffy (dev--random-api-key)> http --auth the-new-tenant:f294a2a7-4225-4115-b352-613459c41c7e get http://localhost:8080/api/v1/tenants
HTTP/1.1 200 OK
content-length: 174
content-type: application/json
date: Thu, 23 Dec 2021 15:33:04 GMT
server: uvicorn

{
    "action": "get",
    "tenants": [
        {
            "active": true,
            "created_at": "2021-12-23T15:31:09+00:00",
            "id": 4,
            "is_admin": false,
            "name": "the-new-tenant",
            "retired_at": null,
            "ssh_key": "**********"
        }
    ]
}
```
- Marvel at the mangled SSH and hidden API keys!