### PR TITLE
Suppress deprecation warnings from Kombu & Flake8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ postgresql = ["psycopg2"]
 [tool.pytest.ini_options]
 addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --flake8 --isort"
 flake8-max-line-length = 100
+filterwarnings = ["ignore::DeprecationWarning:kombu:82", "ignore::DeprecationWarning:flake8:254"]
 
 [tool.isort]
 line_length = 100


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

Before

![Screenshot from 2022-01-25 10-21-54](https://user-images.githubusercontent.com/49605954/150913692-62ef74d6-54a8-470f-8f9b-32d437002358.png)

After

![Screenshot from 2022-01-25 10-18-09](https://user-images.githubusercontent.com/49605954/150913703-ac8eacef-12de-43c1-86ea-c571406c792a.png)

The warnings spawn from the code that the libraries have and NOT the code that we wrote so having them being displayed can be distracting. We are better off ignoring those warnings.