### PR TITLE
Deprovision nodes when a session is retired

### DIFF
--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -20,6 +20,7 @@ class NodesSpec(BaseModel):
 
 
 class SessionNodeModel(NodeBase):
+    id: int
     state: Optional[NodeState]
 
 

--- a/duffy/app/controllers/session.py
+++ b/duffy/app/controllers/session.py
@@ -183,11 +183,11 @@ async def update_session(
     if not session.active:
         raise HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, f"session {id} is retired")
 
-    session.active = data.active
-
-    # mark nodes to be deprovisioned
-    for session_node in session.session_nodes:
-        session_node.node.state = NodeState.deprovisioning
+    if not data.active:
+        session.active = data.active
+        # mark nodes to be deprovisioned
+        for session_node in session.session_nodes:
+            session_node.node.state = NodeState.deprovisioning
 
     await db_async_session.commit()
 

--- a/duffy/database/model/node.py
+++ b/duffy/database/model/node.py
@@ -71,6 +71,7 @@ class SessionNode(Base):
     @property
     def pydantic_view(self) -> SessionNodeModel:
         args = {
+            "id": self.node.id,
             "hostname": self.node.hostname,
             "ipaddr": self.node.ipaddr,
             "pool": self.node.pool,

--- a/duffy/tasks/__init__.py
+++ b/duffy/tasks/__init__.py
@@ -1,3 +1,4 @@
 from .base import celery, init_tasks  # noqa: F401
+from .deprovision import deprovision_nodes, deprovision_pool_nodes  # noqa: F401
 from .main import start_worker  # noqa: F401
 from .provision import fill_pools, fill_single_pool  # noqa: F401

--- a/duffy/tasks/deprovision.py
+++ b/duffy/tasks/deprovision.py
@@ -1,0 +1,160 @@
+from collections import defaultdict
+from typing import List
+
+from celery.utils.log import get_task_logger
+from sqlalchemy import select
+
+from ..database import sync_session_maker
+from ..database.model import Node
+from ..database.types import NodeState
+from .base import celery
+from .mechanisms import MechanismFailure
+from .node_pools import ConcreteNodePool, NodePool
+
+log = get_task_logger(__name__)
+
+NODE_FIELDS_TO_CONSIDER = {"id", "hostname", "ipaddr", "data"}
+
+
+@celery.task(bind=True)
+def deprovision_pool_nodes(self, pool_name: str, node_ids: List[int]):
+    log.debug("[%s] Deprovisioning nodes from pool (begin): %r", pool_name, node_ids)
+
+    try:
+        pool = NodePool.known_pools[pool_name]
+    except KeyError:
+        log.error("[%s] Can't find pool.", pool_name)
+        return
+
+    if not isinstance(pool, ConcreteNodePool):
+        log.error("[%s] Pool must be a concrete node pool.", pool_name)
+        return
+
+    try:
+        with sync_session_maker() as db_sync_session, db_sync_session.begin():
+            nodes = (
+                db_sync_session.execute(
+                    select(Node)
+                    .filter_by(active=True, pool=pool_name, state=NodeState.deployed)
+                    .filter(Node.id.in_(node_ids))
+                )
+                .scalars()
+                .all()
+            )
+
+            for node in nodes:
+                node.state = NodeState.deprovisioning
+
+        found_node_ids = {node.id for node in nodes}
+        not_found_node_ids = set(node_ids) - found_node_ids
+
+        if not_found_node_ids:
+            log.warning(
+                "[%s] Didn't find deployed nodes with ids: %s", pool_name, not_found_node_ids
+            )
+
+        log.debug("[%s] Attempting to deprovision nodes: %r", pool_name, found_node_ids)
+
+        with sync_session_maker() as db_sync_session, db_sync_session.begin():
+            nodes = [db_sync_session.merge(node, load=False) for node in nodes]
+
+            try:
+                deprov_result = pool.deprovision(nodes)
+            except MechanismFailure:
+                log.error("[%s] Deprovisioning mechanism failed.", pool.name)
+                log.debug("[%s] Marking nodes as failed in database.", pool.name)
+                with sync_session_maker() as db_sync_session_in_exc, db_sync_session_in_exc.begin():
+                    for node in nodes:
+                        exc_node = db_sync_session_in_exc.merge(node, load=False)
+                        exc_node.data["error"] = "deprovisioning failed"
+                        exc_node.state = NodeState.failed
+                raise
+
+            unmatched_nodes = set(nodes)
+            matched_nodes = set()
+
+            for node_res in deprov_result["nodes"]:
+                # match up nodes with the data blurb from their provisioning
+                for node in unmatched_nodes:
+                    matched = False
+
+                    for fname in NODE_FIELDS_TO_CONSIDER:
+                        if fname not in node_res:
+                            continue
+
+                        if getattr(node, fname) != node_res[fname]:
+                            matched = False
+                            break
+
+                        matched = True
+
+                    if matched:
+                        # at least one field considered was matched
+                        matched_nodes.add(node)
+                        unmatched_nodes.remove(node)
+                        break
+                else:
+                    # didn't break out of loop -> no node object matched
+                    log.warning("[%s] Node result couldn't be matched: %r", pool.name, node_res)
+
+            if unmatched_nodes:
+                # handle & report nodes the apparently weren't deprovisioned
+                unmatched_ids = []
+                for node in unmatched_nodes:
+                    unmatched_ids.append(node.id)
+                    node.state = NodeState.failed
+
+                log.warning("[%s] Nodes unmatched in result: %r", pool.name, sorted(unmatched_ids))
+
+            # clean up DB objects of deprovisioned nodes
+            for node in matched_nodes:
+                if node.reusable:
+                    node.state = NodeState.unused
+                else:
+                    node.state = NodeState.done
+                    node.active = False
+    except Exception:
+        log.error("[%s] Deprovisioning failed: %r", pool_name, node_ids)
+        raise
+
+    log.debug("[%s] Deprovisioning nodes from pool (end): %r", pool_name, node_ids)
+
+
+@celery.task
+def deprovision_nodes(node_ids: List[int]):
+    """Deprovision nodes e.g. of an expired session.
+
+    This divides up nodes by their pools and kicks off sub tasks for
+    each pool.
+    """
+    log.debug("deprovision_nodes(%r) begin", node_ids)
+    pools_node_ids = defaultdict(list)
+
+    with sync_session_maker() as db_sync_session, db_sync_session.begin():
+        # First, find the -- active, deployed -- nodes with the supplied ids, sort them by their
+        # pools and change their state to 'deprovisioning', then kick off sub tasks which
+        # deprovision all nodes that belong to the same pool.
+        nodes = (
+            db_sync_session.execute(
+                select(Node)
+                .filter_by(active=True, state=NodeState.deployed)
+                .filter(Node.id.in_(node_ids))
+            )
+            .scalars()
+            .all()
+        )
+
+        found_node_ids = {node.id for node in nodes}
+        not_found_node_ids = sorted(set(node_ids) - found_node_ids)
+
+        if not_found_node_ids:
+            log.warning("Didn't find deployed nodes with ids: %s", not_found_node_ids)
+
+        for node in nodes:
+            pools_node_ids[node.pool].append(node.id)
+
+    for pool_name, node_ids in pools_node_ids.items():
+        log.debug("Creating task to deprovision session nodes in pool %s", pool_name)
+        deprovision_pool_nodes.delay(pool_name=pool_name, node_ids=node_ids).forget()
+
+    log.debug("deprovision_nodes(%r) end", node_ids)

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -131,6 +131,9 @@ class TestSessionWorkflow:
         response = await client.post(self.path, json=request_payload)
         result = response.json()
 
+        # fill_pools should never be called directly, just through .delay()
+        fill_pools.assert_not_called()
+
         if testcase == "normal":
             assert response.status_code == HTTP_201_CREATED
 
@@ -160,7 +163,7 @@ class TestSessionWorkflow:
                         # didn't break out of loop -> matches spec
                         matched_nodes_count += 1
                 assert matched_nodes_count == quantity
-            assert len(fill_pools.delay.call_args_list) == 1
+            fill_pools.delay.assert_called_once()
             args, kwargs = fill_pools.delay.call_args
             assert args == ()
             assert kwargs.keys() == {"pool_names"}

--- a/tests/tasks/playbooks/deprovision.yml
+++ b/tests/tasks/playbooks/deprovision.yml
@@ -1,0 +1,57 @@
+- hosts: localhost
+  become: no
+  gather_facts: no
+
+  tasks:
+    # The playbook consumes structures of this form passed in by the mechanism
+    # in the Ansible variable `duffy_in`:
+    #
+    # duffy_in ->
+    #   {
+    #     "nodes": [
+    #       {
+    #         "id": 1,
+    #         "hostname": "...",
+    #         "ipaddr": "...",
+    #         "data": {"provision": {...}}
+    #       },
+    #       {
+    #         "id": 2,
+    #         "hostname": "...",
+    #         "ipaddr": "...",
+    #         "data": {"provision": {...}}
+    #       },
+    #       ...
+    #     ]
+    #   }
+    #
+    # The data.provision field of a node contains the result returned for that
+    # node from the provisioning playbook and should contain all necessary
+    # information to perform the deprovisioning (e.g. a machine id specific to
+    # the used cloud management software).
+
+    # This task emulates deprovisioning the nodes, its result can be arbitrary
+    # in principle, but ...
+    - name: "Deprovision the things!"
+      set_fact:
+        mech_specific_result: >-
+          {{ mech_specific_result | default([]) + [item] }}
+      loop: "{{ duffy_in.nodes | list }}"
+
+    # ... this (mandatory) task has to be able to transform it into the
+    # expected output format, i.e. set a fact `duffy_out` which repeats enough
+    # of the data passed into the playbook for each successfully deprovisioned
+    # node to clearly correlate results with node objects (the `id` field
+    # should suffice) so Duffy can chalk up nodes for reuse, or mark them as
+    # retired or failed appropriately.
+    #
+    # duffy_out ->
+    #   {
+    #     "nodes": [{"id": 1, ...}, {"id": 2, ...}]
+    #   }
+    - name: "Summarize the things!"
+      set_fact:
+        duffy_out:
+          nodes: "{{ mech_specific_result | json_query(mech_specific_query) }}"
+      vars:
+        mech_specific_query: "[*]"

--- a/tests/tasks/test_deprovision.py
+++ b/tests/tasks/test_deprovision.py
@@ -1,0 +1,265 @@
+import logging
+from collections import defaultdict
+from pathlib import Path
+from unittest import mock
+
+import pytest
+from sqlalchemy import func, select
+
+from duffy.database.model import Node
+from duffy.tasks import deprovision
+from duffy.tasks.mechanisms import MechanismFailure
+from duffy.tasks.node_pools import ConcreteNodePool, NodePool
+
+from ..util import noop_context
+
+HERE = Path(__file__).parent
+PLAYBOOK_PATH = HERE / "playbooks"
+
+
+@mock.patch.dict(NodePool.known_pools, clear=True)
+@pytest.mark.parametrize(
+    "testcase",
+    (
+        "normal-dispose-nodes",
+        "normal-dispose-nodes-real-playbook",
+        "normal-reuse-nodes",
+        "normal-reuse-nodes-real-playbook",
+        "normal-unknown-node-id",
+        "normal-spurious-mechanism-result",
+        "normal-incomplete-result-fields",
+        "almost-normal-node-unhandled",
+        "unknown-pool",
+        "abstract-pool",
+        "mechanism-failure",
+    ),
+)
+def test_deprovision_pool_nodes(testcase, test_mechanism, db_sync_session, caplog):
+    expectation = noop_context()
+    real_playbook = "real-playbook" in testcase
+
+    if "unknown-pool" in testcase:
+        pool_name = "bar"
+    else:
+        pool_name = "foo"
+
+    if "abstract-pool" in testcase:
+        pool = NodePool(name="foo")
+        # allow this to be mocked below even though it's missing on plain NodePool objects
+        pool.deprovision = mock.MagicMock()
+        pool.mechanism = mock.MagicMock()
+    else:
+        if real_playbook:
+            mech_config = {
+                "type": "ansible",
+                "ansible": {
+                    "topdir": str(PLAYBOOK_PATH.absolute()),
+                    "playbooks": {"deprovision": "deprovision.yml"},
+                },
+            }
+        else:
+            mech_config = {"type": "test", "test": {}}
+
+        pool = ConcreteNodePool(name="foo", mechanism=mech_config)
+
+    with db_sync_session.begin():
+        # create some testing nodes
+        reusable = "reuse-nodes" in testcase
+        nodes = [
+            Node(
+                id=id,
+                state="deployed",
+                pool="foo",
+                reusable=reusable,
+                data={"provision": {"mech_id": id + 20}},
+            )
+            for id in range(1, 5)
+        ]
+        db_sync_session.add_all(nodes)
+
+        node_ids = [node.id for node in nodes]
+        if "unknown-node-id" in testcase:
+            node_ids.append(32)
+
+    if real_playbook:
+        wraps_pool_deprovision = pool.deprovision
+        wraps_mech_deprovision = pool.mechanism.deprovision
+    else:
+        wraps_pool_deprovision = wraps_mech_deprovision = None
+
+    caplog.clear()
+
+    with mock.patch.object(
+        pool, "deprovision", wraps=wraps_pool_deprovision
+    ) as pool_deprovision, mock.patch.object(
+        pool.mechanism, "deprovision", wraps=wraps_mech_deprovision
+    ) as pool_mech_deprovision, caplog.at_level(
+        "DEBUG"
+    ):
+        if "mechanism-failure" not in testcase:
+            if not real_playbook:
+                mech_result = {
+                    "nodes": [
+                        {
+                            "id": node.id,
+                            "hostname": node.hostname,
+                            "ipaddr": node.ipaddr,
+                            "data": node.data,
+                            # the following should be ignored when matching results with nodes
+                            "something": "unrelated",
+                        }
+                        for node in nodes
+                    ]
+                }
+                if "node-unhandled" in testcase:
+                    del mech_result["nodes"][-1]
+                if "spurious-mechanism-result" in testcase:
+                    mech_result["nodes"].append({"foo": "boop"})
+                if "incomplete-result-fields" in testcase:
+                    for node in mech_result["nodes"]:
+                        del node["ipaddr"]
+                pool_deprovision.return_value = mech_result
+        else:
+            pool_deprovision.side_effect = MechanismFailure("you should have bought a squirrel")
+            expectation = pytest.raises(MechanismFailure)
+
+        with expectation as excinfo:
+            deprovision.deprovision_pool_nodes(pool_name, node_ids)
+
+    # expire all objects to avoid getting back cached ones
+    db_sync_session.expire_all()
+
+    with db_sync_session.begin():
+        nodes = db_sync_session.execute(select(Node)).scalars().all()
+        node_ids = {node.id for node in nodes}
+
+        if "normal" in testcase or "mechanism-failure" in testcase:
+            pool_deprovision.assert_called_once()
+            args, kwargs = pool_deprovision.call_args
+            (nodes_in_call,) = args
+            assert not kwargs
+
+            if "normal" in testcase:
+                for warnings_testcase in (
+                    "unknown-node-id",
+                    "spurious-mechanism",
+                    "node-unhandled",
+                ):
+                    if warnings_testcase in testcase:
+                        max_loglevel = logging.WARNING
+                        break
+                else:
+                    max_loglevel = logging.INFO
+                assert all(rec.levelno <= max_loglevel for rec in caplog.records)
+
+                assert {node.id for node in nodes_in_call} == node_ids
+                if real_playbook:
+                    pool_mech_deprovision.assert_called_once()
+                    mechargs, mechkwargs = pool_mech_deprovision.call_args
+                    assert not mechargs
+                    assert {node.id for node in mechkwargs["nodes"]} == node_ids
+
+                if "reuse-nodes" in testcase:
+                    final_state = "unused"
+                    active = True
+                else:
+                    final_state = "done"
+                    active = False
+                if "node-unhandled" in testcase:
+                    assert all(rec.levelno < logging.ERROR for rec in caplog.records)
+                    counts = defaultdict(int)
+                    for node in nodes:
+                        if node.active:
+                            counts["active"] += 1
+                        else:
+                            counts["retired"] += 1
+                        if node.state == final_state:
+                            counts["final_state"] += 1
+                        else:
+                            assert node.state == "failed"
+                            counts["failed"] += 1
+                    assert counts["active"] == 1
+                    assert counts["failed"] == 1
+                    assert counts["retired"] == len(nodes) - 1
+                    assert counts["final_state"] == len(nodes) - 1
+                else:
+                    assert all(node.active == active for node in nodes)
+                    assert all(node.state == final_state for node in nodes)
+            else:
+                assert "[foo] Deprovisioning mechanism failed." in caplog.messages
+                # refreshing node.id won't work on exception
+                assert len(nodes_in_call) == len(nodes)
+                assert str(excinfo.value) == "you should have bought a squirrel"
+                assert all(node.active for node in nodes)
+                assert all(node.state == "failed" for node in nodes)
+        else:
+            pool_deprovision.assert_not_called()
+            assert all(node.state == "deployed" for node in nodes)
+            if "unknown-pool" in testcase:
+                assert "[bar] Can't find pool." in caplog.messages
+            elif "abstract-pool" in testcase:
+                assert "[foo] Pool must be a concrete node pool." in caplog.messages
+
+
+@pytest.mark.parametrize("testcase", ("normal", "unknown-ids"))
+@mock.patch("duffy.tasks.deprovision.deprovision_pool_nodes")
+def test_deprovision_nodes(deprovision_pool_nodes, testcase, db_sync_session, caplog):
+    known_ids = []
+    unknown_ids = []
+    with db_sync_session.begin():
+        # create some node objects for testing
+        nodes = [
+            Node(id=id, state="deployed", pool="odd" if id % 2 else "even") for id in range(1, 6)
+        ]
+        if "unknown-ids" in testcase:
+            # ensure one isn't deployed
+            nodes[2].state = "ready"
+        for node in nodes:
+            if node.state == "deployed":
+                known_ids.append(node.id)
+            else:
+                unknown_ids.append(node.id)
+        db_sync_session.add_all(nodes)
+
+    # sort by pool name to verify calls to deprovision_pool_nodes() below
+    node_ids_by_pool = {
+        pool_name: {
+            node.id for node in nodes if node.pool == pool_name and node.state == "deployed"
+        }
+        for pool_name in ("odd", "even")
+    }
+    node_ids = [node.id for node in nodes]
+    if "unknown-ids" in testcase:
+        # add one unknown node id
+        node_ids += [32]
+        unknown_ids.append(32)
+
+    deprovision_pool_nodes.delay = delay = mock.MagicMock()
+
+    caplog.clear()
+    deprovision.deprovision_nodes(node_ids)
+
+    deprovision_pool_nodes.assert_not_called()
+
+    found_pool_names = set()
+    for args, kwargs in delay.call_args_list:
+        assert not args
+        pool_name = kwargs["pool_name"]
+        found_pool_names.add(pool_name)
+        node_ids = node_ids_by_pool[pool_name]
+        assert set(kwargs["node_ids"]) == node_ids
+
+    assert node_ids_by_pool.keys() == found_pool_names
+    if "unknown-ids" in testcase:
+        assert f"Didn't find deployed nodes with ids: {unknown_ids}" in caplog.messages
+    else:
+        assert all("Didn't find deployed nodes with ids:" not in m for m in caplog.messages)
+
+    with db_sync_session.begin():
+        # deprovision_nodes() doesn't set nodes to "deprovisioning"
+        deprovisioning_nodes_count = db_sync_session.execute(
+            select(func.count()).select_from(
+                select(Node).filter_by(state="deprovisioning").subquery()
+            )
+        ).scalar_one()
+        assert deprovisioning_nodes_count == 0


### PR DESCRIPTION
This is based on top of #197 and contains the deprovisioning side of backend tasks. When retiring a session (setting `active` to `false` in the API), it should kick off backend tasks that (assuming node pools with configured Ansible mechanisms) kick off the respective deprovisioning playbooks and either return the nodes to the set of `unused` reusable nodes (baremetal), or retire the node objects themselves.