### PR TITLE
(De)contextualize nodes

### DIFF
--- a/duffy/nodes_context.py
+++ b/duffy/nodes_context.py
@@ -1,0 +1,90 @@
+"""
+Contextualize nodes.
+
+This means appending the SSH public key of a tenant to
+/root/.ssh/authorized_keys on the node.
+
+The file must already be present and contain the SSH public key of the Duffy
+user.
+"""
+
+import asyncio
+import logging
+from asyncio.subprocess import DEVNULL, PIPE
+from typing import List, Optional, Sequence
+
+log = logging.getLogger(__name__)
+
+SSH_CMD_FLAGS_BASE = ["/usr/bin/ssh", "-q"]
+SSH_CMD_OPTIONS = [
+    "CheckHostIP=no",
+    "ConnectionAttempts=5",
+    "EscapeChar=none",
+    "ForwardAgent=no",
+    "ForwardX11=no",
+    "PasswordAuthentication=no",
+    "PubkeyAuthentication=yes",
+    "RequestTTY=no",
+    "StrictHostKeyChecking=no",
+    "UserKnownHostsFile=/dev/null",
+]
+SSH_CMD_FLAGS = SSH_CMD_FLAGS_BASE + [item for option in SSH_CMD_OPTIONS for item in ("-o", option)]
+TENANT_CRED_SEPARATOR = "### DUFFY tenant credentials"
+SSH_REMOTE_CONTEXTUALIZE_CMD = "cat - >> ~root/.ssh/authorized_keys"
+SSH_REMOTE_DECONTEXTUALIZE_CMD = (
+    f"sed -i -n '/{TENANT_CRED_SEPARATOR}/q;p' ~root/.ssh/authorized_keys"
+)
+
+
+async def run_remote_cmd(node: str, cmd: str, stdin_text: Optional[str] = None) -> Optional[str]:
+    """Run a shell command on a remote node."""
+    log.debug("run_remote_cmd(%r, %r, ...)", node, cmd)
+    ssh_flags_cmd = SSH_CMD_FLAGS + [f"root@{node}", cmd]
+
+    proc = await asyncio.create_subprocess_exec(
+        *ssh_flags_cmd, stdin=PIPE, stdout=DEVNULL, stderr=DEVNULL
+    )
+
+    if stdin_text:
+        inputval = stdin_text.encode()
+    else:
+        inputval = None
+    stdout, stderr = await proc.communicate(input=inputval)
+
+    await proc.wait()
+
+    if not proc.returncode:
+        return node
+
+
+async def decontextualize_one(node: str) -> Optional[str]:
+    """Decontextualize one node.
+
+    Removes a previously added tenant SSH public key from the list of
+    authorized keys on a node (if it exists).
+    """
+    return await run_remote_cmd(node, SSH_REMOTE_DECONTEXTUALIZE_CMD)
+
+
+async def decontextualize(nodes: Sequence[str]) -> List[Optional[str]]:
+    """Decontextualize several nodes."""
+    return await asyncio.gather(*(decontextualize_one(node=node) for node in nodes))
+
+
+async def contextualize_one(node: str, ssh_pubkey: str) -> Optional[str]:
+    """Contextualize one node.
+
+    This adds the provided SSH public key to the list of authorized keys on
+    the provisioned node and returns the name/IP address of the node on
+    success.
+    """
+    if await decontextualize_one(node):
+        stdin_text = f"{TENANT_CRED_SEPARATOR}\n{ssh_pubkey}\n"
+        return await run_remote_cmd(node, SSH_REMOTE_CONTEXTUALIZE_CMD, stdin_text=stdin_text)
+
+
+async def contextualize(nodes: Sequence[str], ssh_pubkey: str) -> List[Optional[str]]:
+    """Contextualize several nodes."""
+    return await asyncio.gather(
+        *(contextualize_one(node=node, ssh_pubkey=ssh_pubkey) for node in nodes)
+    )

--- a/duffy/tasks/deprovision.py
+++ b/duffy/tasks/deprovision.py
@@ -44,6 +44,7 @@ def deprovision_pool_nodes(self, pool_name: str, node_ids: List[int]):
 
             for node in nodes:
                 node.state = NodeState.deprovisioning
+                node.pool = None
 
         found_node_ids = {node.id for node in nodes}
         not_found_node_ids = set(node_ids) - found_node_ids

--- a/duffy/tasks/deprovision.py
+++ b/duffy/tasks/deprovision.py
@@ -67,7 +67,7 @@ def deprovision_pool_nodes(self, pool_name: str, node_ids: List[int]):
                 with sync_session_maker() as db_sync_session_in_exc, db_sync_session_in_exc.begin():
                     for node in nodes:
                         exc_node = db_sync_session_in_exc.merge(node, load=False)
-                        exc_node.data["error"] = "deprovisioning failed"
+                        exc_node.data["error"] = "deprovisioning mechanism failed"
                         exc_node.state = NodeState.failed
                 raise
 
@@ -103,6 +103,7 @@ def deprovision_pool_nodes(self, pool_name: str, node_ids: List[int]):
                 unmatched_ids = []
                 for node in unmatched_nodes:
                     unmatched_ids.append(node.id)
+                    node.data["error"] = "deprovisioning node failed"
                     node.state = NodeState.failed
 
                 log.warning("[%s] Nodes unmatched in result: %r", pool.name, sorted(unmatched_ids))

--- a/duffy/tasks/provision.py
+++ b/duffy/tasks/provision.py
@@ -73,7 +73,9 @@ def fill_single_pool(pool_name: str):
                 raise RuntimeError(f"[{pool.name}] Skipping filling up")
 
             # This queries up to `quantity` usable nodes, or fewer.
-            nodes = db_sync_session.execute(usable_nodes_query.limit(quantity)).scalars().all()
+            usable_nodes_query = usable_nodes_query.limit(quantity)
+            log.debug("Usable nodes query: %s", usable_nodes_query)
+            nodes = db_sync_session.execute(usable_nodes_query).scalars().all()
             log.info("Found %d suitable unused nodes.", len(nodes))
         else:
             log.debug("[%s] Allocating %d new node objects in database", pool.name, quantity)

--- a/duffy/tasks/provision.py
+++ b/duffy/tasks/provision.py
@@ -46,6 +46,10 @@ def fill_single_pool(pool_name: str):
             quantity,
         )
 
+        if quantity <= 0:
+            log.debug("[%s] Pool is filled to or above spec.", pool.name)
+            return
+
         reuse_nodes = pool.get("reuse-nodes")
         if reuse_nodes:
             log.debug("[%s] Searching for %d reusable nodes in database", pool.name, quantity)

--- a/tests/tasks/test_deprovision.py
+++ b/tests/tasks/test_deprovision.py
@@ -169,6 +169,7 @@ def test_deprovision_pool_nodes(testcase, test_mechanism, db_sync_session, caplo
                     assert all(rec.levelno < logging.ERROR for rec in caplog.records)
                     counts = defaultdict(int)
                     for node in nodes:
+                        assert node.pool is None
                         if node.active:
                             counts["active"] += 1
                         else:

--- a/tests/test_nodes_context.py
+++ b/tests/test_nodes_context.py
@@ -1,0 +1,117 @@
+from asyncio.subprocess import DEVNULL, PIPE
+from unittest import mock
+
+import pytest
+
+from duffy import nodes_context
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("with_stdin", (True, False))
+@pytest.mark.parametrize("success", (True, False))
+@mock.patch("asyncio.create_subprocess_exec")
+async def test_run_remote_cmd(create_subprocess_exec, success, with_stdin):
+    create_subprocess_exec.return_value = proc = mock.AsyncMock()
+    proc.returncode = not success
+    proc.communicate.return_value = (None, None)
+
+    CMD = "what a command"
+    NODE = "node.domain.tld"
+    if with_stdin:
+        STDIN_TEXT = "BOOO"
+    else:
+        STDIN_TEXT = None
+    result = await nodes_context.run_remote_cmd(node=NODE, cmd=CMD, stdin_text=STDIN_TEXT)
+
+    create_subprocess_exec.assert_awaited_with(
+        *(nodes_context.SSH_CMD_FLAGS + [f"root@{NODE}", CMD]),
+        stdin=PIPE,
+        stdout=DEVNULL,
+        stderr=DEVNULL,
+    )
+
+    proc.communicate.assert_awaited()
+    input_value = proc.communicate.call_args.kwargs["input"]
+    if with_stdin:
+        assert STDIN_TEXT.encode() == input_value
+    else:
+        assert input_value is None
+
+    proc.wait.assert_awaited_once_with()
+
+    if success:
+        assert result == NODE
+    else:
+        assert result is None
+
+
+@pytest.mark.asyncio
+@mock.patch("duffy.nodes_context.run_remote_cmd")
+async def test_decontextualize_one(run_remote_cmd):
+    run_remote_cmd.return_value = sentinel = object()
+    NODE = "node.domain.tld"
+
+    result = await nodes_context.decontextualize_one(node=NODE)
+
+    run_remote_cmd.assert_awaited_once_with(NODE, nodes_context.SSH_REMOTE_DECONTEXTUALIZE_CMD)
+
+    assert result == sentinel
+
+
+@pytest.mark.asyncio
+@mock.patch("duffy.nodes_context.decontextualize_one")
+async def test_decontextualize(decontextualize_one):
+    nodes = [f"node{idx}.domain.tld" for idx in range(1, 6)]
+    decontextualize_one.side_effect = nodes
+
+    decontextualize_result = await nodes_context.decontextualize(nodes)
+
+    assert decontextualize_result == nodes
+
+    decontextualize_one.assert_has_awaits(mock.call(node=node) for node in nodes)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decontextualize_fail", (False, True))
+@mock.patch("duffy.nodes_context.run_remote_cmd")
+@mock.patch("duffy.nodes_context.decontextualize_one")
+async def test_contextualize_one(decontextualize_one, run_remote_cmd, decontextualize_fail):
+    SSH_PUBKEY = "BOOP"
+    NODE = "node.domain.tld"
+
+    if decontextualize_fail:
+        decontextualize_one.return_value = False
+    else:
+        run_remote_cmd.return_value = NODE
+
+    result = await nodes_context.contextualize_one(ssh_pubkey=SSH_PUBKEY, node=NODE)
+
+    decontextualize_one.assert_awaited_once_with(NODE)
+
+    if not decontextualize_fail:
+        run_remote_cmd.assert_awaited_once()
+        assert run_remote_cmd.call_args.args == (NODE, nodes_context.SSH_REMOTE_CONTEXTUALIZE_CMD)
+        assert run_remote_cmd.call_args.kwargs == {
+            "stdin_text": f"{nodes_context.TENANT_CRED_SEPARATOR}\n{SSH_PUBKEY}\n"
+        }
+        assert result == NODE
+    else:
+        run_remote_cmd.assert_not_awaited()
+        assert result is None
+
+
+@pytest.mark.asyncio
+@mock.patch("duffy.nodes_context.contextualize_one")
+async def test_contextualize(contextualize_one):
+    nodes = [f"node{idx}.domain.tld" for idx in range(1, 6)]
+    contextualize_one.side_effect = nodes
+
+    SSH_PUBKEY = "BOOP"
+
+    contextualize_result = await nodes_context.contextualize(nodes, SSH_PUBKEY)
+
+    assert contextualize_result == nodes
+
+    contextualize_one.assert_has_awaits(
+        mock.call(ssh_pubkey=SSH_PUBKEY, node=node) for node in nodes
+    )


### PR DESCRIPTION
This adds functions to add/remove tenant keys to/from nodes and uses them in the session-POST endpoint which should in theory add the last functional gap so people can actually create sessions with nodes and use them (#227 still missing to reclaim nodes if tenants fail to do so by themselves).

# How to test?

Good question! At the moment I can think of one way (absent having a functioning OpenNebula cluster, which I don't):

- Have a stripped down Duffy configuration with only one pool
  - Configure with a limit of N (e.g. 1) and `reuse-nodes` set appropriately, i.e. the node objects in the database must have `reusable` set and their data field must have the fields specified in `reuse-nodes` set appropriately. E.g. going by the example, their `data` JSON field would have to have `architecture` set correctly.
  - Configure its Ansible mechanism to use playbooks modelled after the testing playbooks in `tests/tasks/playbooks` (see documentation in these playbooks). I imagine the playbooks could even work verbatim for this, they're basically a huge load of noop.
- Have N machines set up statically (e.g. as VMs but any machine with SSH set up would do -- needs that the user running the Duffy app can log into the machine without password)
- Add the machine(s) as nodes in the Duffy DB (state=unused, reusable=True, hostname and ipaddr appropriately)
- Remove/retire other nodes from the DB
- Start the task worker
- Start the app
- Request session using the API

This is what should roughly happen (it tests more things than just contextualization):

- The task worker should attempt to fill up the pool from the unused node(s) on startup.
- When requesting the session, the machines requested are assigned to the session and contextualized, i.e. the SSH pub key of the tenant used in the request is installed in their `/root/.ssh/authorized_keys` files.
- The task worker will attempt to fill up the pool which can fail if not enough unused nodes are available to fill it up to spec.
- You should be able to log into the requested nodes using the tenant SSH key.
- When the session is set to inactive, all requested nodes should be deprovisioned, i.e. returned to state=unused and pool unset).