### PR TITLE
Fix passing variables into playbooks

### DIFF
--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -20,11 +20,6 @@ class MechanismType(str, Enum):
     ansible = "ansible"
 
 
-class PlaybookType(str, Enum):
-    provision = "provision"
-    deprovision = "deprovision"
-
-
 # Pydantic models
 
 
@@ -51,10 +46,16 @@ class DatabaseModel(BaseModel):
     sqlalchemy: SQLAlchemyModel
 
 
+class AnsibleMechanismPlaybookModel(BaseModel):
+    extra_vars: Optional[Dict[str, Any]] = Field(alias="extra-vars")
+    playbook: Path
+
+
 class AnsibleMechanismModel(BaseModel):
     topdir: Optional[Path]
     extra_vars: Optional[Dict[str, Any]] = Field(alias="extra-vars")
-    playbooks: Optional[Dict[PlaybookType, Path]]
+    provision: Optional[AnsibleMechanismPlaybookModel]
+    deprovision: Optional[AnsibleMechanismPlaybookModel]
 
 
 class MechanismModel(BaseModel):

--- a/duffy/tasks/node_pools.py
+++ b/duffy/tasks/node_pools.py
@@ -71,14 +71,19 @@ class NodePool(dict):
         for pool in cls.known_pools.values():
             yield pool
 
-    def render_template(self, template: str) -> str:
-        return jinja2.Template(template).render(**self)
+    def render_template(self, template: str, overrides: Optional[Dict[str, Any]] = None) -> str:
+        template_vars = dict(self)
+        if overrides:
+            template_vars = {**self, **overrides}
+        return jinja2.Template(template).render(**template_vars)
 
-    def render_templates_in_obj(self, obj: Any) -> Any:
+    def render_templates_in_obj(self, obj: Any, overrides: Optional[Dict[str, Any]] = None) -> Any:
         if isinstance(obj, str):
-            return self.render_template(obj)
+            return self.render_template(obj, overrides)
         elif isinstance(obj, dict):
-            return {key: self.render_templates_in_obj(value) for key, value in obj.items()}
+            return {
+                key: self.render_templates_in_obj(value, overrides) for key, value in obj.items()
+            }
         else:
             return obj
 

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -139,9 +139,10 @@ nodepools:
         architecture: "{{ architecture }}"
       mechanism:
         ansible:
-          playbooks:
-            provision: "playbooks/baremetal/provision.yml"
-            deprovision: "playbooks/baremetal/deprovision.yml"
+          provision:
+            playbook: "playbooks/baremetal/provision.yml"
+          deprovision:
+            playbook: "playbooks/baremetal/deprovision.yml"
     physical-x86_64:
       extends: physical
       fill-level: 5
@@ -152,15 +153,16 @@ nodepools:
       reuse-nodes: false
       mechanism:
         ansible:
-          extra-vars:
-            # duffy.nodes gets passed in as a list
-            quantity: "{{ duffy.nodes | length }}"
-            # remove "virtual-", add "duffy-" prefix
-            template_name: >-
-              {% set parts=name.split("-") %}duffy-{{ parts[1:] | join("-") }}
-          playbooks:
-            provision: "playbooks/opennebula/provision.yml"
-            deprovision: "playbooks/opennebula/deprovision.yml"
+          provision:
+            extra-vars:
+              # duffy_in.nodes gets passed in as a list
+              quantity: "{{ duffy_in.nodes | length }}"
+              # remove "virtual-", add "duffy-" prefix
+              template_name: >-
+                {% set parts=name.split("-") %}duffy-{{ parts[1:] | join("-") }}
+            playbook: "playbooks/opennebula/provision.yml"
+          deprovision:
+            playbook: "playbooks/opennebula/deprovision.yml"
     virtual-x86_64-small:
       extends: virtual
       fill-level: 20

--- a/tests/tasks/test_deprovision.py
+++ b/tests/tasks/test_deprovision.py
@@ -54,7 +54,7 @@ def test_deprovision_pool_nodes(testcase, test_mechanism, db_sync_session, caplo
                 "type": "ansible",
                 "ansible": {
                     "topdir": str(PLAYBOOK_PATH.absolute()),
-                    "playbooks": {"deprovision": "deprovision.yml"},
+                    "deprovision": {"playbook": "deprovision.yml"},
                 },
             }
         else:

--- a/tests/tasks/test_node_pools.py
+++ b/tests/tasks/test_node_pools.py
@@ -120,9 +120,15 @@ class TestNodePool:
 
         assert set(pool.name for pool in NodePool.iter_pools()) == expected
 
-    def test_render_template(self):
-        pool = NodePool(name="foo", bar="hello")
-        assert pool.render_template("{{ bar }} - {{ name }}") == "hello - foo"
+    @pytest.mark.parametrize("with_overrides", (False, True))
+    def test_render_template(self, with_overrides):
+        if with_overrides:
+            pool = NodePool(name="foo")
+            overrides = {"bar": "hello"}
+        else:
+            pool = NodePool(name="foo", bar="hello")
+            overrides = None
+        assert pool.render_template("{{ bar }} - {{ name }}", overrides) == "hello - foo"
 
     def test_render_template_in_obj(self):
         pool = NodePool(name="foo", bar="hello", baz="goodbye")

--- a/tests/tasks/test_provision.py
+++ b/tests/tasks/test_provision.py
@@ -78,7 +78,7 @@ def test_fill_single_pool(testcase, db_sync_session, test_mechanism, caplog):
             "type": "ansible",
             "ansible": {
                 "topdir": str(PLAYBOOK_PATH.absolute()),
-                "playbooks": {"provision": "provision.yml"},
+                "provision": {"playbook": "provision.yml"},
             },
         }
     else:


### PR DESCRIPTION
Previously, the `duffy_in` variable wasn't available for templates in
configuration which caused provisioning tasks to raise an exception –
which in turn referenced the wrong missing key because the example
configuration wasn't adapted to later changes in the (de-)provisioning
framework: In an earlier stage of developing the provisioning/deprovisioning
framework, data was passed in and out using an Ansible extra variable or
fact called `duffy`. This didn't ensure that a result is actually set in
the playbook (rather than the input "falling through"), so this was
changed to the extra variable passed in being called `duffy_in` and the
playbook having to set the fact `duffy_out`.

Addtionally, you could only configure one set of extra variables for
both provisioning and deprovisioning playbooks.

Fixes: #242

Signed-off-by: Nils Philippsen <nils@redhat.com>