### PR TITLE
Add `systemd` unit files

### DIFF
--- a/etc/systemd/system/duffy-app.service
+++ b/etc/systemd/system/duffy-app.service
@@ -1,0 +1,15 @@
+[Unit]
+After=network.target
+# Comment out the following line if the `duffy-tasks.service` and `duffy-app.service` are NOT running on the same machine
+Requires=duffy-tasks.service
+
+[Service]
+User=duffy
+Group=duffy
+# Adjust the path of the `duffy` executable in your virtual environment
+ExecStart=/path/to/duffy-virtualenv/bin/duffy -c /etc/duffy-config.yaml serve
+
+[Install]
+WantedBy=default.target
+# Comment out the following line if the `duffy-metaclient.service` and `duffy-app.service` are NOT running on the same machine
+RequiredBy=duffy-metaclient.service

--- a/etc/systemd/system/duffy-metaclient.service
+++ b/etc/systemd/system/duffy-metaclient.service
@@ -1,0 +1,13 @@
+[Unit]
+After=network.target
+# Comment out the following line if the `duffy-metaclient.service` and `duffy-app.service` are NOT running on the same machine
+Requires=duffy-app.service
+
+[Service]
+User=duffy
+Group=duffy
+# Adjust the path of the `duffy` executable in your virtual environment
+ExecStart=/path/to/duffy-virtualenv/bin/duffy -c /etc/duffy-config.yaml serve-legacy
+
+[Install]
+WantedBy=default.target

--- a/etc/systemd/system/duffy-tasks.service
+++ b/etc/systemd/system/duffy-tasks.service
@@ -1,0 +1,13 @@
+[Unit]
+After=network.target
+
+[Service]
+User=duffy
+Group=duffy
+# Adjust the path of the `duffy` executable in your virtual environment
+ExecStart=/path/to/duffy-virtualenv/bin/duffy -c /etc/duffy-config.yaml worker -B --schedule-filename /var/lib/duffy-schedule
+
+[Install]
+WantedBy=default.target
+# Comment out the following line if the `duffy-tasks.service` and `duffy-app.service` are NOT running on the same machine
+RequiredBy=duffy-app.service


### PR DESCRIPTION
Signed-off-by: Akashdeep Dhar <akashdeep.dhar@gmail.com>

First, enable/start the worker (`worker.duffy.service`), then enable/start the primary (`primary.duffy.service`) and then enable/start the legacy (`legacy.duffy.service`).

Feel free to suggest changes in the name, whilst I am led to believe that the order that I stated before should stay the same.

Fixes #263