### PR TITLE
Extend session expiration times

### DIFF
--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -1,10 +1,11 @@
 from abc import ABC
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, conint
 
 from ..database.types import NodeState
+from ..misc import APITimeDelta
 from .common import APIResult, CreatableMixin, RetirableMixin
 from .node import NodeBase
 from .tenant import TenantModel
@@ -39,7 +40,8 @@ class SessionCreateModel(SessionBase):
 
 
 class SessionUpdateModel(SessionBase):
-    active: bool
+    active: Optional[bool]
+    expires_at: Optional[Union[datetime, APITimeDelta]]
 
 
 class SessionModel(SessionBase, CreatableMixin, RetirableMixin):

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -2,7 +2,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, Literal, Optional, Union
 
-from pydantic import AnyUrl, BaseModel, Field, conint, stricturl
+from pydantic import AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl
 
 from ..misc import ConfigTimeDelta
 
@@ -30,12 +30,17 @@ class CeleryModel(BaseModel):
     result_backend: AnyUrl
 
 
+class LockingModel(BaseModel):
+    url: RedisDsn
+
+
 class PeriodicTaskModel(BaseModel):
     interval: conint(gt=0)
 
 
 class TasksModel(BaseModel):
     celery: CeleryModel
+    locking: LockingModel
     periodic: Optional[Dict[str, PeriodicTaskModel]]
 
 

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -55,6 +55,7 @@ class DatabaseModel(BaseModel):
 
 class MiscModel(BaseModel):
     session_lifetime: ConfigTimeDelta = Field(alias="session-lifetime")
+    session_lifetime_max: ConfigTimeDelta = Field(alias="session-lifetime-max")
 
 
 class AnsibleMechanismPlaybookModel(BaseModel):

--- a/duffy/tasks/expire.py
+++ b/duffy/tasks/expire.py
@@ -8,13 +8,16 @@ from ..database import sync_session_maker
 from ..database.model import Session, SessionNode
 from .base import celery
 from .deprovision import deprovision_nodes
+from .locking import Lock
 
 log = get_task_logger(__name__)
 
 
 @celery.task
 def expire_sessions():
-    with sync_session_maker() as db_sync_session, db_sync_session.begin():
+    with Lock(
+        key="duffy:expire_sessions"
+    ), sync_session_maker() as db_sync_session, db_sync_session.begin():
         now = dt.datetime.utcnow().replace(tzinfo=dt.timezone.utc)
 
         expired_sessions = (

--- a/duffy/tasks/locking.py
+++ b/duffy/tasks/locking.py
@@ -1,0 +1,16 @@
+from functools import wraps
+
+from pottery import Redlock
+from redis import Redis
+
+from ..configuration import config
+
+
+class Lock(Redlock):
+    """Redlock, using Duffy configuration."""
+
+    @wraps(Redlock.__init__)
+    def __init__(self, *, masters=None, **kwargs):
+        if not masters:
+            masters = {Redis.from_url(config["tasks"]["locking"]["url"])}
+        super().__init__(masters=masters, **kwargs)

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -107,6 +107,8 @@ tasks:
     broker_url: "redis://localhost:6379"
     result_backend: "redis://localhost:6379"
     worker_redirect_stdouts_level: "INFO"
+  locking:
+    url: "redis://localhost:6379"
   periodic:
     fill-pools:
       interval: 300

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -123,6 +123,7 @@ database:
 
 misc:
   session-lifetime: "6h"
+  session-lifetime-max: "12h"
 
 nodepools:
   abstract:

--- a/poetry.lock
+++ b/poetry.lock
@@ -811,6 +811,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "mmh3"
+version = "3.0.0"
+description = "Python wrapper for MurmurHash (MurmurHash3), a set of fast and robust hash functions."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "mypy"
 version = "0.910"
 description = "Optional static typing for Python"
@@ -935,6 +943,19 @@ python-versions = ">=3.6"
 [package.extras]
 dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
+name = "pottery"
+version = "3.0.0"
+description = "Redis for Humans."
+category = "main"
+optional = false
+python-versions = ">=3.7, <4"
+
+[package.dependencies]
+mmh3 = "*"
+redis = ">=4,<5"
+typing-extensions = "*"
 
 [[package]]
 name = "prompt-toolkit"
@@ -1496,12 +1517,12 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 interactive = ["ipython"]
 legacy = ["httpx"]
 postgresql = ["psycopg2"]
-tasks = ["ansible-runner", "ansible-core", "ansible", "Jinja2", "jmespath"]
+tasks = ["ansible-runner", "ansible-core", "ansible", "Jinja2", "jmespath", "pottery"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "cef2427d5d1884abacd15fbec34f3a53508f380c1e51729fd24988b9297ff877"
+content-hash = "dd1a1bfd37ac096d5c3c68d9ebe1f4a725ed256ab0467d23bab631f3a4b756c0"
 
 [metadata.files]
 aiosqlite = [
@@ -1938,6 +1959,34 @@ mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
+mmh3 = [
+    {file = "mmh3-3.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:23912dde2ad4f701926948dd8e79a0e42b000f73962806f153931f52985e1e07"},
+    {file = "mmh3-3.0.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:07f1308a410dc406d6a3c282a685728d00a87f3ed684f012671b96d6cc6a41c3"},
+    {file = "mmh3-3.0.0-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:167cbc2b5ae27f3bccd797a2e8a9e7561791bee4cc2885f2c140eedc5df000ef"},
+    {file = "mmh3-3.0.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:8fb833c2942917eff54f984b067d93e5a3c54dbb00720323460cdfed9292835f"},
+    {file = "mmh3-3.0.0-cp36-cp36m-win32.whl", hash = "sha256:b7d26d0243ed9a5b8bf7aa8c53697cb79dff1e1d207f42396b7a7cb2a62298b7"},
+    {file = "mmh3-3.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2b6c79fc314b34b911245b460a79b601fff39bb807521fb7ed7c15cacf0394ac"},
+    {file = "mmh3-3.0.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:6d0b3e9def1fdfe4eadd35ee26bf72bd715ba97711f7101302d54c9d2e70ba27"},
+    {file = "mmh3-3.0.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8803d28c17cf898f5f00c0433e8b13d51fa3bb4ebecf59872ba1eaa20d94128a"},
+    {file = "mmh3-3.0.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:01e456edf9cc381298a590923aadd1c0bf9934d93433099a5001d656112437c2"},
+    {file = "mmh3-3.0.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ff69ddc2d46e3e42720840b6b4f7bfb032fd1e677fac347fdfff6e4d9fd01212"},
+    {file = "mmh3-3.0.0-cp37-cp37m-win32.whl", hash = "sha256:e08a5d81a2ff53625953290187bed4ae96a6972e2b5cd5984a6ebc5a9aab256c"},
+    {file = "mmh3-3.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:12484ac80373db77d8a6beb7615e7dac8b6c3fb118905311a51450b4fc4a24d1"},
+    {file = "mmh3-3.0.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:93c96e657e9bf9e9ef12ddaeae9f109c0b3134146e2eff2cbddde5a34190920e"},
+    {file = "mmh3-3.0.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9097be65aa95460bc68b6108601da8894757532450daf74034e4eaecd536acca"},
+    {file = "mmh3-3.0.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:19874e12acb4119ef1ef83062ef4ac953c3343dd07a67ede8fa096d0393f34be"},
+    {file = "mmh3-3.0.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:4589adcb609d1547aac7c1ac1064eb27cdd44b65b7e8a114e2971cd3b7110306"},
+    {file = "mmh3-3.0.0-cp38-cp38-win32.whl", hash = "sha256:7a311efd4ecf122f21392ec6bf447c620cc783d20bdb9aec60bb469a54318419"},
+    {file = "mmh3-3.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:3566d1455fa4a09f8fb1aa5b37f68914949674f9aa2bd630e9fdf344207f55b5"},
+    {file = "mmh3-3.0.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:92fdffd63edb67c30dbaba18a7448d762209c0e678b0c9d577d17b30362b59a3"},
+    {file = "mmh3-3.0.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e52b869572c09db0c1a483f6e9cedbccfae8a282d95e552d3d4bd0712ab3196"},
+    {file = "mmh3-3.0.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:f1cce018cc82a8a6287e6aeb139e441129837b810f2ddf372e3ff7f0fefb0947"},
+    {file = "mmh3-3.0.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:0fd09c4b61fcddbcf0a87d5463b4e6d2919896736a67efc5248d5c74c1c9c742"},
+    {file = "mmh3-3.0.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c17fe2e276edd37ad8a6aff3b1663d3479c2c5c5993539c1050422a1dae33033"},
+    {file = "mmh3-3.0.0-cp39-cp39-win32.whl", hash = "sha256:150439b906b4deaf6d796b2c2d11fb6159f08d02330d97723071ab3bf43b51df"},
+    {file = "mmh3-3.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:bd870aedd9189eff1cf4e1687869b56c7e9461ee869789139c3e704009e5c227"},
+    {file = "mmh3-3.0.0.tar.gz", hash = "sha256:d1ec578c09a07d3518ec9be540b87546397fa3455de73c166fcce51eaa5c41c5"},
+]
 mypy = [
     {file = "mypy-0.910-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:a155d80ea6cee511a3694b108c4494a39f42de11ee4e61e72bc424c490e46457"},
     {file = "mypy-0.910-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:b94e4b785e304a04ea0828759172a15add27088520dc7e49ceade7834275bedb"},
@@ -2035,6 +2084,10 @@ platformdirs = [
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
     {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
+]
+pottery = [
+    {file = "pottery-3.0.0-py3-none-any.whl", hash = "sha256:0190323bbb1289d40c5cd683feb04c4b8cff76a6c723f3ded9137c8bcc9fb5f8"},
+    {file = "pottery-3.0.0.tar.gz", hash = "sha256:adda303e9357442bcac1d4c7f86aa7deec855e0190c101d09448afbcf5676a74"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.28-py3-none-any.whl", hash = "sha256:30129d870dcb0b3b6a53efdc9d0a83ea96162ffd28ffe077e94215b233dc670c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ ansible-core = {version = "^2.12.1", optional = true}
 ansible-runner = {version = "^2.1.1", optional = true}
 Jinja2 = {version = "^3.0.3", optional = true}
 jmespath = {version = "^0.10.0", optional = true}
+pottery = {version = "^3.0.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = "^21.9b0"
@@ -71,11 +72,12 @@ ansible-core = "^2.12.1"
 ansible-runner = "^2.1.1"
 Jinja2 = "^3.0.3"
 jmespath = "^0.10.0"
+pottery = "^3.0.0"
 
 [tool.poetry.extras]
 interactive = ["ipython"]
 postgresql = ["psycopg2"]
-tasks = ["ansible-runner", "ansible-core", "ansible", "Jinja2", "jmespath"]
+tasks = ["ansible-runner", "ansible-core", "ansible", "Jinja2", "jmespath", "pottery"]
 legacy = ["httpx"]
 
 [tool.pytest.ini_options]

--- a/tests/tasks/test_locking.py
+++ b/tests/tasks/test_locking.py
@@ -1,0 +1,29 @@
+from unittest import mock
+
+import pytest
+
+from duffy.configuration import config
+from duffy.tasks.locking import Lock
+
+
+class TestLock:
+    @pytest.mark.duffy_config(example_config=True)
+    @pytest.mark.parametrize("masters_from_config", (True, False))
+    @mock.patch("duffy.tasks.locking.Redis")
+    def test_masters___init__(self, Redis, masters_from_config):
+        sentinel = mock.Mock()
+        Redis.from_url.return_value = sentinel
+
+        kwargs = {"key": "a key"}
+        if masters_from_config:
+            redis_obj = Redis()
+            kwargs["masters"] = {redis_obj}
+
+        lock = Lock(**kwargs)
+
+        if not masters_from_config:
+            Redis.from_url.assert_called_once_with(config["tasks"]["locking"]["url"])
+            assert lock.masters == {sentinel}
+        else:
+            Redis.from_url.assert_not_called()
+            assert lock.masters == {redis_obj}

--- a/tests/tasks/test_main.py
+++ b/tests/tasks/test_main.py
@@ -10,6 +10,7 @@ TEST_CONFIG = {
             "broker_url": "redis://localhost:6379",
             "result_backend": "redis://localhost:6379",
         },
+        "locking": {"url": "redis:///"},
         "periodic": {"fill-pools": {"interval": 5}, "expire-sessions": {"interval": 7}},
     }
 }


### PR DESCRIPTION
This extends the session/update endpoint to accept a new field, `expires_at` (which can be a datetime or timedelta value, the latter in the format implemented by `duffy.misc.APITimeDelta`) to extend session lifetimes past their default value (of 6 hours). The legacy metaclient uses this to implement `/Node/fail`.

Fixes: #279 