### PR TITLE
Better configurability

### DIFF
--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -15,7 +15,7 @@ from .exceptions import DuffyConfigurationError
 from .tasks import start_worker
 from .version import __version__
 
-DEFAULT_CONFIG_FILE = "/etc/duffy.yaml"
+DEFAULT_CONFIG_FILE = "/etc/duffy"
 
 log = logging.getLogger(__name__)
 
@@ -37,13 +37,14 @@ def init_config(ctx, param, filename):
 @click.option(
     "-c",
     "--config",
-    type=click.Path(dir_okay=False),
+    type=click.Path(),
     default=DEFAULT_CONFIG_FILE,
     callback=init_config,
     is_eager=True,
     expose_value=False,
-    help="Read option defaults from the specified YAML file.",
+    help="Read configuration from the specified YAML files or directories.",
     show_default=True,
+    metavar="FILE_OR_DIR",
 )
 @click.version_option(version=__version__, prog_name="Duffy")
 def cli():

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -24,11 +24,13 @@ log = logging.getLogger(__name__)
 
 
 def init_config(ctx, param, filename):
+    ctx.ensure_object(dict)
     try:
-        read_configuration(filename)
+        read_configuration(filename, clear=ctx.obj.get("clear_config", True))
     except FileNotFoundError:
         if filename is not DEFAULT_CONFIG_FILE:
             raise
+    ctx.obj["clear_config"] = False
 
 
 @click.group(name="duffy")

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -26,7 +26,7 @@ log = logging.getLogger(__name__)
 def init_config(ctx, param, filename):
     ctx.ensure_object(dict)
     try:
-        read_configuration(filename, clear=ctx.obj.get("clear_config", True))
+        read_configuration(filename, clear=ctx.obj.get("clear_config", True), validate=False)
     except FileNotFoundError:
         if filename is not DEFAULT_CONFIG_FILE:
             raise
@@ -48,7 +48,7 @@ def init_config(ctx, param, filename):
 )
 @click.version_option(version=__version__, prog_name="Duffy")
 def cli():
-    pass
+    read_configuration(clear=False, validate=True)
 
 
 # Check & dump configuration

--- a/duffy/configuration/main.py
+++ b/duffy/configuration/main.py
@@ -1,3 +1,4 @@
+from itertools import chain
 from pathlib import Path
 from typing import List, Union
 
@@ -9,11 +10,24 @@ from .validation import ConfigModel
 config = {}
 
 
+def _expand_normalize_config_files(config_files: List[Union[Path, str]]) -> List[Path]:
+    config_file_paths = []
+
+    for path in config_files:
+        if not isinstance(path, Path):
+            path = Path(path)
+        if path.is_dir():
+            config_file_paths.extend(sorted(chain(path.glob("*.yaml"), path.glob("*.yml"))))
+        else:
+            config_file_paths.append(path)
+
+    return config_file_paths
+
+
 def read_configuration(*config_files: List[Union[Path, str]], clear: bool = True):
+    config_files = _expand_normalize_config_files(config_files)
     new_config = {}
     for config_file in config_files:
-        if not isinstance(config_file, Path):
-            config_file = Path(config_file)
         with config_file.open("r") as fp:
             for config_doc in yaml.safe_load_all(fp):
                 # validate configuration file

--- a/duffy/configuration/main.py
+++ b/duffy/configuration/main.py
@@ -24,16 +24,19 @@ def _expand_normalize_config_files(config_files: List[Union[Path, str]]) -> List
     return config_file_paths
 
 
-def read_configuration(*config_files: List[Union[Path, str]], clear: bool = True):
+def read_configuration(
+    *config_files: List[Union[Path, str]], clear: bool = True, validate: bool = True
+):
     config_files = _expand_normalize_config_files(config_files)
     new_config = {}
     for config_file in config_files:
         with config_file.open("r") as fp:
             for config_doc in yaml.safe_load_all(fp):
-                # validate configuration file
-                ConfigModel(**config_doc)
-
                 new_config = merge_dicts(new_config, config_doc)
+
+    if validate:
+        # validate merged configuration
+        ConfigModel(**new_config)
 
     if clear:
         config.clear()

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -2,6 +2,7 @@ import copy
 from pathlib import Path
 
 import pytest
+import yaml
 
 from duffy.configuration import main
 from duffy.util import merge_dicts
@@ -51,3 +52,17 @@ class TestConfiguration:
     def test_read_configuration_multiple_override(self, duffy_config_files):
         assert len(duffy_config_files) > 1
         assert main.config == merge_dicts(EXAMPLE_CONFIG, {"app": {"host": "host.example.net"}})
+
+    @pytest.mark.duffy_config({"app": {}})
+    def test_read_configuration_partial(self, duffy_config_files, tmp_path):
+        assert main.config == EXAMPLE_CONFIG
+
+    @pytest.mark.duffy_config(example_config=True, clear=True)
+    def test_read_configuration_partial_validate_post(self, duffy_config_files, tmp_path):
+        partial_config_file = tmp_path / "partial-config.yaml"
+        with partial_config_file.open("w") as fp:
+            yaml.dump({"metaclient": {}}, fp)
+
+        main.read_configuration(partial_config_file, clear=True, validate=False)
+        main.read_configuration(*duffy_config_files, clear=False, validate=False)
+        main.read_configuration(clear=False, validate=True)

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -1,4 +1,5 @@
 import copy
+from pathlib import Path
 
 import pytest
 
@@ -10,6 +11,23 @@ EXAMPLE_CONFIG = {"app": {"host": "127.0.0.1", "port": 8080}}
 
 @pytest.mark.duffy_config(EXAMPLE_CONFIG, clear=True)
 class TestConfiguration:
+    @pytest.mark.parametrize("objtype", (str, Path))
+    def test__expand_normalize_config_files(self, objtype, tmp_path, duffy_config_files):
+        (config_file,) = duffy_config_files
+
+        sub_file1 = tmp_path / "sub_file1.yaml"
+        sub_file1.touch()
+
+        sub_file2 = tmp_path / "sub_file2.yaml"
+        sub_file2.touch()
+
+        config_files = [config_file, tmp_path]
+        expanded_config_files = main._expand_normalize_config_files(
+            [objtype(f) for f in config_files]
+        )
+
+        assert expanded_config_files == [config_file, sub_file1, sub_file2]
+
     @pytest.mark.parametrize("clear", (True, False))
     def test_read_configuration_clear(self, clear):
         main.read_configuration(clear=clear)


### PR DESCRIPTION
Fix some issues around configuring duffy:

- Only clear configuration once so multiple --config options make sense
- Allow specifying whole configuration directories
- Make multiple configuration files more useful, i.e. only validate the complete merged configuration, not every single file.