### PR TITLE
Subcommand to manage tenants in the CLI, misc fixes

### DIFF
--- a/duffy/admin.py
+++ b/duffy/admin.py
@@ -1,0 +1,76 @@
+import asyncio
+import logging
+import sys
+from typing import Optional
+
+from fastapi import HTTPException
+from sqlalchemy import select
+
+from .api_models import TenantCreateModel, TenantRetireModel, TenantUpdateModel
+from .app.controllers import tenant
+from .database import async_session_maker, init_model, sync_session_maker
+from .database.model import Tenant
+from .exceptions import DuffyConfigurationError
+
+log = logging.getLogger(__name__)
+
+
+class FakeAPITenant:
+    is_admin = True
+
+
+class AdminContext:
+    def __init__(self):
+        self.fake_api_tenant = FakeAPITenant()
+        init_model()
+
+    @classmethod
+    def create_for_cli(cls):
+        """This exits the program if creating an AdminContext throws an exception."""
+        try:
+            admin_ctx = cls()
+        except DuffyConfigurationError as exc:
+            log.error("Configuration key missing or wrong: %s", exc.args[0])
+            sys.exit(1)
+        else:
+            return admin_ctx
+
+    async def proxy_controller_function_async(self, controller_function, **kwargs):
+        async with async_session_maker() as db_async_session:
+            try:
+                return await controller_function(
+                    tenant=self.fake_api_tenant, db_async_session=db_async_session, **kwargs
+                )
+            except HTTPException as exc:
+                return {"error": {"detail": exc.detail}}
+
+    def proxy_controller_function(self, controller_function, **kwargs):
+        return asyncio.run(self.proxy_controller_function_async(controller_function, **kwargs))
+
+    def get_tenant_id(self, name: str):
+        with sync_session_maker() as db_sync_session:
+            return db_sync_session.execute(
+                select(Tenant.id).filter_by(name=name)
+            ).scalar_one_or_none()
+
+    def create_tenant(self, name: str, ssh_key: str, is_admin: bool = False):
+        return self.proxy_controller_function(
+            tenant.create_tenant,
+            data=TenantCreateModel(name=name, ssh_key=ssh_key, is_admin=is_admin),
+        )
+
+    def retire_unretire_tenant(self, name: str, retire: bool):
+        return self.proxy_controller_function(
+            tenant.update_tenant,
+            id=self.get_tenant_id(name),
+            data=TenantRetireModel(active=not retire),
+        )
+
+    def update_tenant(
+        self, name: str, api_key: Optional[str] = None, ssh_key: Optional[str] = None
+    ):
+        return self.proxy_controller_function(
+            tenant.update_tenant,
+            id=self.get_tenant_id(name),
+            data=TenantUpdateModel(api_key=api_key, ssh_key=ssh_key),
+        )

--- a/duffy/api_models/__init__.py
+++ b/duffy/api_models/__init__.py
@@ -15,4 +15,8 @@ from .tenant import (  # noqa: F401
     TenantModel,
     TenantResult,
     TenantResultCollection,
+    TenantRetireModel,
+    TenantUpdateModel,
+    TenantUpdateResult,
+    TenantUpdateResultModel,
 )

--- a/duffy/api_models/tenant.py
+++ b/duffy/api_models/tenant.py
@@ -1,7 +1,7 @@
 from abc import ABC
-from typing import List, Optional
+from typing import List, Literal, Optional, Union
 
-from pydantic import UUID4, BaseModel, SecretStr
+from pydantic import UUID4, BaseModel, SecretStr, root_validator
 
 from .common import APIResult, CreatableMixin, RetirableMixin
 
@@ -21,12 +21,31 @@ class TenantCreateModel(TenantBase):
     pass
 
 
+class TenantRetireModel(BaseModel):
+    active: bool
+
+
+class TenantUpdateModel(BaseModel):
+    ssh_key: Optional[SecretStr]
+    api_key: Optional[Union[UUID4, Literal["reset"]]]
+
+    @root_validator
+    def check_ssh_key_or_api_key(cls, values):
+        if not values.get("ssh_key") and not values.get("api_key"):
+            raise ValueError("either ssh_key or api_key is required")
+        return values
+
+
 class TenantModel(TenantBase, CreatableMixin, RetirableMixin):
     id: int
 
 
 class TenantCreateResultModel(TenantModel):
     api_key: UUID4
+
+
+class TenantUpdateResultModel(TenantModel):
+    api_key: Optional[Union[UUID4, SecretStr]]
 
 
 # API results
@@ -41,6 +60,10 @@ class TenantCreateResult(TenantResult):
 
     class Config:
         json_encoders = {SecretStr: lambda v: v.get_secret_value() if v else None}
+
+
+class TenantUpdateResult(TenantResult):
+    tenant: TenantUpdateResultModel
 
 
 class TenantResultCollection(APIResult):

--- a/duffy/tasks/provision.py
+++ b/duffy/tasks/provision.py
@@ -33,7 +33,7 @@ def fill_single_pool(pool_name: str):
     # needed to fill it up to spec. If this was done concurrently for the same pool, both tasks
     # would allocate the same number of new nodes, overfilling the pool.
     with Lock(
-        key=f"duffy:fill-single-pool:{pool_name}",
+        key="duffy:fill-single-pool:allocate-nodes-in-db"
     ), sync_session_maker() as db_sync_session, db_sync_session.begin():
         log.debug("[%s] Determining number of available nodes ...", pool.name)
         current_fill_level = db_sync_session.execute(

--- a/duffy/tasks/provision.py
+++ b/duffy/tasks/provision.py
@@ -91,7 +91,10 @@ def fill_single_pool(pool_name: str):
             usable_nodes_query = usable_nodes_query.limit(quantity)
             log.debug("Usable nodes query: %s", usable_nodes_query)
             nodes = db_sync_session.execute(usable_nodes_query).scalars().all()
-            log.info("Found %d suitable unused nodes.", len(nodes))
+            log.info("Found %d suitable unused node(s).", len(nodes))
+            if len(nodes) < 1:
+                log.warning("[%s] No sense continuing, bailing out.", pool.name)
+                return
         else:
             log.debug("[%s] Allocating %d new node objects in database", pool.name, quantity)
             nodes = [Node() for i in range(quantity)]

--- a/poetry.lock
+++ b/poetry.lock
@@ -49,7 +49,7 @@ vine = ">=5.0.0"
 name = "ansible"
 version = "5.6.0"
 description = "Radically simple IT automation"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 
@@ -60,7 +60,7 @@ ansible-core = ">=2.12.4,<2.13.0"
 name = "ansible-core"
 version = "2.12.4"
 description = "Radically simple IT automation"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.8"
 
@@ -465,7 +465,7 @@ python-versions = ">=3.6,<4.0"
 name = "cryptography"
 version = "36.0.2"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -1533,7 +1533,7 @@ requests = ">=2.0.1,<3.0.0"
 name = "resolvelib"
 version = "0.5.5"
 description = "Resolve abstract dependencies into concrete ones"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -1892,12 +1892,12 @@ interactive = ["ipython"]
 legacy = ["httpx"]
 opennebula = ["pyone"]
 postgresql = ["psycopg2", "asyncpg"]
-tasks = ["ansible-runner", "ansible-core", "ansible", "Jinja2", "jmespath", "pottery"]
+tasks = ["ansible-runner", "Jinja2", "jmespath", "pottery"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "b865241cc9ed873d2c6acd67bf4814ddd8228986a8e98e14dbb45f216787609a"
+content-hash = "e2a58c91062d36eb97a66cacfe9b758da8eb5d476b1eb42a7e6ff3dcc67a141a"
 
 [metadata.files]
 aenum = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,6 @@ click = "^8.0.3,<8.1"
 fastapi = ">=0.70,<0.76"
 uvicorn = ">=0.15,<0.18"
 Jinja2 = {version = "^3.0.3", optional = true}
-ansible = {version = "^5.2", optional = true}
-ansible-core = {version = "^2.12.1", optional = true}
 ansible-runner = {version = "^2.1.1", optional = true}
 asyncpg = {version = "^0.25", optional = true}
 celery = {version = "^5.2.1", extras = ["redis"]}
@@ -80,7 +78,7 @@ tox = "^3.24.4"
 [tool.poetry.extras]
 interactive = ["ipython"]
 postgresql = ["psycopg2", "asyncpg"]
-tasks = ["ansible-runner", "ansible-core", "ansible", "Jinja2", "jmespath", "pottery"]
+tasks = ["ansible-runner", "Jinja2", "jmespath", "pottery"]
 opennebula = ["pyone"]
 legacy = ["httpx"]
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,155 @@
+import uuid
+from unittest import mock
+
+import pytest
+from fastapi import HTTPException
+from starlette.status import HTTP_422_UNPROCESSABLE_ENTITY
+
+from duffy import api_models
+from duffy.admin import AdminContext
+from duffy.app import controllers
+from duffy.database.model import Tenant
+from duffy.exceptions import DuffyConfigurationError
+
+from .util import noop_context
+
+
+@pytest.fixture
+def admin_ctx():
+    return AdminContext()
+
+
+@pytest.mark.duffy_config(example_config=True)
+class TestAdminContext:
+    @mock.patch("duffy.admin.init_model")
+    @mock.patch("duffy.admin.FakeAPITenant")
+    def test___init__(self, FakeAPITenant, init_model):
+        FakeAPITenant.return_value = sentinel = object()
+
+        ctx = AdminContext()
+
+        assert ctx.fake_api_tenant is sentinel
+
+        FakeAPITenant.assert_called_once_with()
+        init_model.assert_called_once_with()
+
+    @pytest.mark.parametrize("testcase", ("success", "config-error"))
+    @mock.patch.object(AdminContext, "__new__")
+    def test_create_for_cli(self, admin_ctx_new, testcase, caplog):
+        if testcase == "success":
+            expectation = noop_context()
+            admin_ctx_new.return_value = sentinel = object()
+        elif testcase == "config-error":
+            admin_ctx_new.side_effect = DuffyConfigurationError("BOO")
+            expectation = pytest.raises(SystemExit)
+
+        with expectation:
+            ctx = AdminContext.create_for_cli()
+
+        if testcase == "success":
+            assert ctx is sentinel
+        else:
+            assert "Configuration key missing or wrong: BOO" in caplog.text
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("testcase", ("success", "exception"))
+    @mock.patch("duffy.admin.async_session_maker")
+    async def test_proxy_controller_function_async(self, async_session_maker, testcase, admin_ctx):
+        async_session_maker.return_value = ctx_mgr = mock.AsyncMock()
+        ctx_mgr.__aenter__.return_value = db_async_session = mock.AsyncMock()
+        controller_function = mock.AsyncMock()
+        if testcase == "success":
+            controller_function.return_value = sentinel = object()
+        else:
+            controller_function.side_effect = HTTPException(
+                HTTP_422_UNPROCESSABLE_ENTITY, detail="BOO"
+            )
+
+        result = await admin_ctx.proxy_controller_function_async(controller_function, foo="bar")
+
+        controller_function.assert_awaited_once_with(
+            tenant=admin_ctx.fake_api_tenant, db_async_session=db_async_session, foo="bar"
+        )
+
+        if testcase == "success":
+            assert result is sentinel
+        else:
+            assert result["error"]["detail"] == "BOO"
+
+    def test_proxy_controller_function(self, admin_ctx):
+        proxy_controller_function_async = mock.AsyncMock()
+        proxy_controller_function_async.return_value = sentinel = object()
+        admin_ctx.proxy_controller_function_async = proxy_controller_function_async
+
+        controller_function = mock.AsyncMock()
+
+        result = admin_ctx.proxy_controller_function(controller_function, foo="bar")
+
+        proxy_controller_function_async.assert_awaited_with(controller_function, foo="bar")
+
+        assert result is sentinel
+
+    def test_get_tenant_id(self, admin_ctx, db_sync_session):
+        tenant = Tenant(name="test", api_key="API_KEY", ssh_key="SSH_KEY")
+        db_sync_session.add(tenant)
+        db_sync_session.commit()
+
+        assert admin_ctx.get_tenant_id("test") == tenant.id
+
+    @pytest.mark.parametrize("testcase", ("normal", "is-admin"))
+    @mock.patch.object(AdminContext, "proxy_controller_function")
+    def test_create_tenant(self, proxy_controller_function, testcase, admin_ctx):
+        is_admin = testcase == "is-admin"
+
+        proxy_controller_function.return_value = sentinel = object()
+
+        result = admin_ctx.create_tenant(name="name", ssh_key="# no ssh key", is_admin=is_admin)
+
+        assert result == sentinel
+
+        proxy_controller_function.assert_called_once_with(
+            controllers.tenant.create_tenant,
+            data=api_models.TenantCreateModel(
+                name="name", ssh_key="# no ssh key", is_admin=is_admin
+            ),
+        )
+
+    @pytest.mark.parametrize("testcase", ("retire", "unretire"))
+    @mock.patch.object(AdminContext, "get_tenant_id")
+    @mock.patch.object(AdminContext, "proxy_controller_function")
+    def test_retire_unretire_tenant(
+        self, proxy_controller_function, get_tenant_id, testcase, admin_ctx
+    ):
+        retire = testcase == "retire"
+        proxy_controller_function.return_value = sentinel = object()
+        get_tenant_id.return_value = 5
+
+        result = admin_ctx.retire_unretire_tenant(name="name", retire=retire)
+
+        assert result == sentinel
+
+        get_tenant_id.assert_called_once_with("name")
+        proxy_controller_function.assert_called_once_with(
+            controllers.tenant.update_tenant,
+            id=5,
+            data=api_models.TenantRetireModel(active=not retire),
+        )
+
+    @mock.patch.object(AdminContext, "get_tenant_id")
+    @mock.patch.object(AdminContext, "proxy_controller_function")
+    def test_update_tenant(self, proxy_controller_function, get_tenant_id, admin_ctx):
+        proxy_controller_function.return_value = sentinel = object()
+        get_tenant_id.return_value = 6
+
+        api_key = uuid.uuid4()
+
+        result = admin_ctx.update_tenant(name="name", api_key=api_key, ssh_key="# new ssh key")
+
+        assert result == sentinel
+
+        get_tenant_id.assert_called_once_with("name")
+        proxy_controller_function.assert_called_once_with(
+            controllers.tenant.update_tenant,
+            id=6,
+            data=api_models.TenantUpdateModel(api_key=api_key, ssh_key="# new ssh key"),
+        )


### PR DESCRIPTION
* Don't depend on ansible, ansible-core
* Use one global lock when provisioning
* Don't attempt to provision zero nodes
* Add CLI subcommand to manage tenants