### PR TITLE
Fix Node.state server-side default

### DIFF
--- a/duffy/database/model/node.py
+++ b/duffy/database/model/node.py
@@ -40,7 +40,7 @@ class Node(Base, CreatableMixin, RetirableMixin):
         NodeState.db_type(),
         nullable=False,
         default=NodeState.unused,
-        server_default=NodeState.ready.value,
+        server_default=NodeState.unused.value,
     )
     comment = Column(UnicodeText, nullable=True)
 


### PR DESCRIPTION
This was fixed on the SQLAlchemy side long ago, oops.

Signed-off-by: Nils Philippsen <nils@redhat.com>