### PR TITLE
Dynamically map legacy parameters to pool names and misc fixes

### DIFF
--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -1,8 +1,9 @@
+import re
 from enum import Enum
 from pathlib import Path
-from typing import Any, Dict, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl
+from pydantic import AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl, validator
 
 from ..misc import ConfigTimeDelta
 
@@ -114,6 +115,19 @@ class AppModel(ConfigBaseModel):
     logging: Optional[LoggingModel]
 
 
+class LegacyPoolMapModel(ConfigBaseModel):
+    pool: str
+    ver: Optional[str]
+    arch: Optional[str]
+    flavor: Optional[str]
+
+    @validator("ver", "arch", "flavor")
+    def detect_regex(cls, v: str):
+        if v.startswith("^") and v.endswith("$"):
+            return re.compile(v)
+        return v
+
+
 class LegacyModel(ConfigBaseModel):
     host: Optional[str]
     port: Optional[conint(gt=0, lt=65536)]
@@ -121,6 +135,7 @@ class LegacyModel(ConfigBaseModel):
     loglevel: Optional[LogLevel]
     logging: Optional[LoggingModel]
     usermap: Dict[str, str]
+    poolmap: List[LegacyPoolMapModel]
 
 
 class ConfigModel(ConfigBaseModel):

--- a/duffy/shell.py
+++ b/duffy/shell.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover
 import sqlalchemy
 
 from . import database
+from .configuration import config
 from .database import model
 from .exceptions import DuffyShellUnavailableError
 
@@ -24,6 +25,7 @@ def get_available_shells():
 
 def get_shell_variables(shell_type: str):
     variables = {
+        "config": config,
         "db_sync_session": database.sync_session_maker(),
         "sqlalchemy": sqlalchemy,
         "select": sqlalchemy.select,

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -50,6 +50,15 @@ metaclient:
   dest: http://127.0.0.1:8080
   usermap:
     "fca07101-daea-4b8c-acb4-88ba8ae7654c": "hahahahahatheystoppedlegacysupporthahahahaha"
+  poolmap:
+  # Valid selection keys: ver, arch, flavor
+  # Values can be simple strings or regexes (surrounded by "^...$")
+  # and must map to a pool which can use Jinja macros.
+  # First match wins.
+  - arch: "^(aarch64|ppc64|ppc64le)$"
+    pool: "virtual-centos{{ ver | replace('-', '') }}-{{ arch }}-{{ flavor | default('medium') }}"
+  - arch: "x86_64"
+    pool: "physical-centos{{ ver | replace('-', '') }}-{{ arch }}"
   logging:
     version: 1
     disable_existing_loggers: false


### PR DESCRIPTION
```
commit 953e8a63442e3a388dca361c06e2ddc2b8641830
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Tue May 3 11:53:19 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 3 11:58:15 2022 +0200

    Add `config` object to locals of interactive shell
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit d240385cbae51ea60435cc658f487ca3cbcbc085
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 2 17:41:36 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 3 11:58:15 2022 +0200

    Enforce only known config fields (mostly)
    
    Previously, any configuration key was accepted, but this was not on
    purpose.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 1cd909bb4b6248589bb8f2e5c995ceba18a22479
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Tue May 3 11:42:46 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 3 13:14:47 2022 +0200

    Dynamically map legacy parameters to pool names
    
    Previously, this was hard-coded but it turned out we want the
    flexibility to map parameters in the legacy metaclient to arbitrary node
    pools.
    
    Fixes: #355
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```