### PR TITLE
Implement node quotas

### DIFF
--- a/duffy/api_models/tenant.py
+++ b/duffy/api_models/tenant.py
@@ -1,7 +1,7 @@
 from abc import ABC
 from typing import List, Literal, Optional, Union
 
-from pydantic import UUID4, BaseModel, SecretStr, root_validator
+from pydantic import UUID4, BaseModel, SecretStr, conint, root_validator
 
 from .common import APIResult, CreatableMixin, RetirableMixin
 
@@ -12,6 +12,7 @@ class TenantBase(BaseModel, ABC):
     name: str
     is_admin: Optional[bool]
     ssh_key: SecretStr
+    node_quota: Optional[conint(gt=0)]
 
     class Config:
         orm_mode = True
@@ -28,16 +29,18 @@ class TenantRetireModel(BaseModel):
 class TenantUpdateModel(BaseModel):
     ssh_key: Optional[SecretStr]
     api_key: Optional[Union[UUID4, Literal["reset"]]]
+    node_quota: Optional[conint(gt=0)]
 
-    @root_validator
-    def check_ssh_key_or_api_key(cls, values):
-        if not values.get("ssh_key") and not values.get("api_key"):
-            raise ValueError("either ssh_key or api_key is required")
+    @root_validator(pre=True)
+    def check_any_field_set(cls, values):
+        if not ("ssh_key" in values or "api_key" in values or "node_quota" in values):
+            raise ValueError("either ssh_key, api_key or node_quota is required")
         return values
 
 
 class TenantModel(TenantBase, CreatableMixin, RetirableMixin):
     id: int
+    effective_node_quota: int
 
 
 class TenantCreateResultModel(TenantModel):

--- a/duffy/app/controllers/tenant.py
+++ b/duffy/app/controllers/tenant.py
@@ -90,6 +90,7 @@ async def create_tenant(
         is_admin=data.is_admin,
         api_key=api_key,
         ssh_key=data.ssh_key.get_secret_value(),
+        node_quota=data.node_quota,
     )
     db_async_session.add(created_tenant)
     try:
@@ -158,6 +159,9 @@ async def update_tenant(
         else:
             updated_tenant.api_key = data.api_key
             api_key = SecretStr("this is hidden anyway")
+
+        if "node_quota" in data.dict(exclude_unset=True):
+            updated_tenant.node_quota = data.node_quota
 
     api_tenant = TenantUpdateResultModel(
         api_key=api_key, **TenantModel.from_orm(updated_tenant).dict()

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -64,6 +64,7 @@ class DatabaseModel(ConfigBaseModel):
 class MiscModel(ConfigBaseModel):
     session_lifetime: ConfigTimeDelta = Field(alias="session-lifetime")
     session_lifetime_max: ConfigTimeDelta = Field(alias="session-lifetime-max")
+    default_node_quota: conint(gt=0) = Field(alias="default-node-quota")
 
 
 class AnsibleMechanismPlaybookModel(ConfigBaseModel):

--- a/duffy/database/model/tenant.py
+++ b/duffy/database/model/tenant.py
@@ -3,7 +3,9 @@ import uuid
 import bcrypt
 from sqlalchemy import Boolean, Column, Integer, Text, UnicodeText, text
 from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy.sql import case
 
+from ...configuration import config
 from .. import Base
 from ..util import CreatableMixin, RetirableMixin
 
@@ -16,6 +18,7 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     is_admin = Column(Boolean, nullable=False, default=False, server_default=text("FALSE"))
     ssh_key = Column(UnicodeText, nullable=False)
     _api_key = Column("api_key", Text, nullable=False)
+    node_quota = Column(Integer, nullable=True)
 
     @hybrid_property
     def api_key(self):
@@ -29,3 +32,17 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
 
     def validate_api_key(self, key: uuid.UUID):
         return bcrypt.checkpw(str(key).encode("ascii"), self._api_key.encode("ascii"))
+
+    @hybrid_property
+    def effective_node_quota(self):
+        if self.node_quota is not None:
+            return self.node_quota
+
+        return config["misc"]["default-node-quota"]
+
+    @effective_node_quota.expression
+    def effective_node_quota(cls):
+        return case(
+            [(cls.node_quota != None, cls.node_quota)],  # noqa: E711
+            else_=config["misc"]["default-node-quota"],
+        )

--- a/duffy/util.py
+++ b/duffy/util.py
@@ -1,3 +1,6 @@
+import enum
+
+
 def camel_case_to_lower_with_underscores(camelcased: str) -> str:
     """Convert CamelCased names to lower_case_with_underscores."""
     chunk_positions = []
@@ -50,3 +53,11 @@ def merge_dicts(*src_dicts):
                 res_dict[key] = src_value
 
     return res_dict
+
+
+class SentinelType(enum.Enum):
+    UNSET = 1
+
+
+UNSET = SentinelType.UNSET
+"""A sentinel object for unset values."""

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -121,6 +121,7 @@ database:
 misc:
   session-lifetime: "6h"
   session-lifetime-max: "12h"
+  default-node-quota: 10
 
 nodepools:
   abstract:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -119,21 +119,25 @@ class TestAdminContext:
         get_tenant_id.assert_called_once_with("name")
         proxy_controller_function.assert_called_once_with(controllers.tenant.get_tenant, id=6)
 
-    @pytest.mark.parametrize("testcase", ("normal", "is-admin"))
+    @pytest.mark.parametrize("testcase", ("normal", "normal-with-quota", "is-admin"))
     @mock.patch.object(AdminContext, "proxy_controller_function")
     def test_create_tenant(self, proxy_controller_function, testcase, admin_ctx):
         is_admin = testcase == "is-admin"
+        with_quota = "with-quota" in testcase
+        node_quota = 5 if with_quota else None
 
         proxy_controller_function.return_value = sentinel = object()
 
-        result = admin_ctx.create_tenant(name="name", ssh_key="# no ssh key", is_admin=is_admin)
+        result = admin_ctx.create_tenant(
+            name="name", ssh_key="# no ssh key", node_quota=node_quota, is_admin=is_admin
+        )
 
         assert result == sentinel
 
         proxy_controller_function.assert_called_once_with(
             controllers.tenant.create_tenant,
             data=api_models.TenantCreateModel(
-                name="name", ssh_key="# no ssh key", is_admin=is_admin
+                name="name", ssh_key="# no ssh key", node_quota=node_quota, is_admin=is_admin
             ),
         )
 


### PR DESCRIPTION
```
commit b658b4b10e152731147ff17b7e9794dfdd92a48d
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Wed May 4 13:46:07 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Wed May 4 13:49:56 2022 +0200

    Add UNSET sentinel object
    
    This is to distinguish explicit None/null values in APIs from being
    unset. It's implemented as an enum type to support type hinting better.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 9e0c3e2dce50b45422a07b2a7c2269a3c3444267
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Tue May 3 19:25:51 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Wed May 4 13:49:56 2022 +0200

    Implement node quotas
    
    This allows configuring a default value (`misc.default-node-quota`) and
    setting specific values for individual tenants.
    
    Fixes: #226
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```