### PR TITLE
Get rid of DELETE methods in the API

### DIFF
--- a/duffy/api_models/common.py
+++ b/duffy/api_models/common.py
@@ -16,7 +16,6 @@ class RetirableMixin(BaseModel):
 
 
 class APIResultAction(str, Enum):
-    delete = "delete"
     get = "get"
     post = "post"
     put = "put"

--- a/duffy/app/controllers/node.py
+++ b/duffy/app/controllers/node.py
@@ -76,26 +76,3 @@ async def create_node(
     await db_async_session.refresh(node)
 
     return {"action": "post", "node": node}
-
-
-@router.delete("/{id}", response_model=NodeResult, tags=["nodes"])
-async def delete_node(
-    id: int,
-    db_async_session: AsyncSession = Depends(req_db_async_session),
-    tenant: Tenant = Depends(req_tenant),
-):
-    """Delete the node with the specified **ID**."""
-    if not tenant.is_admin:
-        raise HTTPException(HTTP_403_FORBIDDEN)
-
-    node = (
-        await db_async_session.execute(select(Node).filter_by(id=id).options(selectinload("*")))
-    ).scalar_one_or_none()
-
-    if not node:
-        raise HTTPException(HTTP_404_NOT_FOUND)
-
-    await db_async_session.delete(node)
-    await db_async_session.commit()
-
-    return {"action": "delete", "node": node}

--- a/duffy/app/controllers/tenant.py
+++ b/duffy/app/controllers/tenant.py
@@ -170,25 +170,3 @@ async def update_tenant(
     await db_async_session.commit()
 
     return {"action": "put", "tenant": api_tenant}
-
-
-# http delete http://localhost:8080/api/v1/tenant/2
-@router.delete("/{id}", response_model=TenantResult, tags=["tenants"])
-async def delete_tenant(
-    id: int,
-    db_async_session: AsyncSession = Depends(req_db_async_session),
-    tenant: Tenant = Depends(req_tenant),
-):
-    """Delete the tenant with the specified **ID**."""
-    if not tenant.is_admin:
-        raise HTTPException(HTTP_403_FORBIDDEN)
-
-    tenant = (await db_async_session.execute(select(Tenant).filter_by(id=id))).scalar_one_or_none()
-
-    if not tenant:
-        raise HTTPException(HTTP_404_NOT_FOUND)
-
-    await db_async_session.delete(tenant)
-    await db_async_session.commit()
-
-    return {"action": "delete", "tenant": tenant}

--- a/tests/app/controllers/__init__.py
+++ b/tests/app/controllers/__init__.py
@@ -249,30 +249,3 @@ class BaseTestController:
         assert obj["id"] == len(objs)
         attrs = {**self.attrs, **self._add_attrs_from_response(create_response)}
         self._verify_item(obj, attrs=attrs)
-
-    @pytest.mark.parametrize(
-        "testcase",
-        (
-            "found",
-            "not found",
-            pytest.param("not admin", marks=pytest.mark.client_auth_as("tenant")),
-        ),
-    )
-    async def test_delete_obj(self, client, testcase, auth_admin):
-        if testcase != "not found":
-            create_response = await self._create_obj(
-                client,
-                client_kwargs={"auth": (auth_admin.name, str(_gen_test_api_key(auth_admin.name)))},
-            )
-            obj_id = create_response.json()[self.name]["id"]
-        else:
-            obj_id = -1
-
-        response = await client.delete(f"{self.path}/{obj_id}")
-
-        if testcase == "found":
-            assert response.status_code == HTTP_200_OK
-        elif testcase == "not admin":
-            assert response.status_code == HTTP_403_FORBIDDEN
-        else:
-            assert response.status_code == HTTP_404_NOT_FOUND


### PR DESCRIPTION
They are an artifact of writing an API skeleton in the first place, but
we don't actually want to delete objects in the database, instead we
retire them. This way we keep historical data for later analysis.

Fixes: #381

Signed-off-by: Nils Philippsen <nils@redhat.com>