### PR TITLE
Don't break API key when updating tenant in other way

### DIFF
--- a/duffy/app/controllers/tenant.py
+++ b/duffy/app/controllers/tenant.py
@@ -157,7 +157,8 @@ async def update_tenant(
             # Set api_key to return the automatically generated one in the result.
             updated_tenant.api_key = api_key = uuid4()
         else:
-            updated_tenant.api_key = data.api_key
+            if data.api_key:
+                updated_tenant.api_key = data.api_key
             api_key = SecretStr("this is hidden anyway")
 
         if "node_quota" in data.dict(exclude_unset=True):


### PR DESCRIPTION
Previously, if `api_key` was set to `null`, it would be set in the
updated tenant (e.g. when updating the SSH key or node quota).

Additionally, test the update_tenant() controller function more
extensively.

Fixes: #383

Signed-off-by: Nils Philippsen <nils@redhat.com>