### PR TITLE
Allow "rich" values for periodic task intervals

### DIFF
--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -43,7 +43,7 @@ class LockingModel(ConfigBaseModel):
 
 
 class PeriodicTaskModel(ConfigBaseModel):
-    interval: conint(gt=0)
+    interval: ConfigTimeDelta
 
 
 class TasksModel(ConfigBaseModel):

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -41,6 +41,8 @@ class TestAPITimeDelta(_BaseTestTimeDelta):
     input_to_expected = {
         "+3h30m": timedelta(hours=3, minutes=30),
         "-2d": timedelta(days=-2),
+        "300": ValueError,
+        300: TypeError,
         "1h": ValueError,
         "": ValueError,
         "+": ValueError,
@@ -59,6 +61,8 @@ class TestConfigTimeDelta(_BaseTestTimeDelta):
     input_to_expected = {
         "+3h30m": timedelta(hours=3, minutes=30),
         "1h": timedelta(hours=1),
+        "300": timedelta(minutes=5),
+        300: timedelta(minutes=5),
         "-2d": ValueError,
         "": ValueError,
         "+": ValueError,


### PR DESCRIPTION
Previously, tasks.periodic.*.interval only accepted dimensionless values
which were interpreted as seconds, while misc.session_lifetime* only
accepted strings using abbreviated dimensions. Now all of them accept
both types of specifications.

Fixes: #387

Signed-off-by: Nils Philippsen <nils@redhat.com>