### PR TITLE
Implement per tenant session lifetimes

### DIFF
--- a/ansible/roles/duffy/defaults/main.yml
+++ b/ansible/roles/duffy/defaults/main.yml
@@ -17,7 +17,7 @@ duffy_config_files:
   - 30_logging
   - 40_tasks
   - 50_database
-  - 60_misc
+  - 60_defaults
   - 70_nodepools
   - 80_secrets
 duffy_app_loglevel: "info"
@@ -37,5 +37,5 @@ duffy_tasks_fill_pools_interval: 300
 duffy_tasks_expire_sessions_interval: 300
 duffy_database_sqlalchemy_sync_url: "postgresql:///duffy"
 duffy_database_sqlalchemy_async_url: "postgresql+asyncpg:///duffy"
-duffy_session_lifetime: "6h"
-duffy_session_lifetime_max: "12h"
+duffy_default_session_lifetime: "6h"
+duffy_default_session_lifetime_max: "12h"

--- a/ansible/roles/duffy/templates/config/60_defaults.yaml.j2
+++ b/ansible/roles/duffy/templates/config/60_defaults.yaml.j2
@@ -1,0 +1,4 @@
+---
+defaults:
+  session-lifetime: "{{ duffy_default_session_lifetime }}"
+  session-lifetime-max: "{{ duffy_default_session_lifetime_max }}"

--- a/ansible/roles/duffy/templates/config/60_misc.yaml.j2
+++ b/ansible/roles/duffy/templates/config/60_misc.yaml.j2
@@ -1,4 +1,0 @@
----
-misc:
-  session-lifetime: "{{ duffy_session_lifetime }}"
-  session-lifetime-max: "{{ duffy_session_lifetime_max }}"

--- a/duffy/admin.py
+++ b/duffy/admin.py
@@ -1,6 +1,7 @@
 import asyncio
 import logging
 import sys
+from datetime import timedelta
 from typing import Optional, Union
 
 from fastapi import HTTPException
@@ -61,12 +62,23 @@ class AdminContext:
         return self.proxy_controller_function(tenant.get_tenant, id=self.get_tenant_id(name))
 
     def create_tenant(
-        self, name: str, ssh_key: str, node_quota: Optional[int], is_admin: bool = False
+        self,
+        name: str,
+        ssh_key: str,
+        node_quota: Optional[int],
+        session_lifetime: Optional[timedelta],
+        session_lifetime_max: Optional[timedelta],
+        is_admin: bool = False,
     ):
         return self.proxy_controller_function(
             tenant.create_tenant,
             data=TenantCreateModel(
-                name=name, ssh_key=ssh_key, is_admin=is_admin, node_quota=node_quota
+                name=name,
+                ssh_key=ssh_key,
+                is_admin=is_admin,
+                node_quota=node_quota,
+                session_lifetime=session_lifetime,
+                session_lifetime_max=session_lifetime_max,
             ),
         )
 
@@ -83,9 +95,11 @@ class AdminContext:
         api_key: Optional[Union[str, SentinelType]] = UNSET,
         ssh_key: Optional[Union[str, SentinelType]] = UNSET,
         node_quota: Optional[Union[int, SentinelType]] = UNSET,
+        session_lifetime: Optional[timedelta] = UNSET,
+        session_lifetime_max: Optional[timedelta] = UNSET,
     ):
         data = {}
-        for key in ("api_key", "ssh_key", "node_quota"):
+        for key in ("api_key", "ssh_key", "node_quota", "session_lifetime", "session_lifetime_max"):
             value = locals()[key]
             if value is not UNSET:
                 data[key] = value

--- a/duffy/app/controllers/session.py
+++ b/duffy/app/controllers/session.py
@@ -23,7 +23,7 @@ from ...api_models import (
     SessionUpdateModel,
 )
 from ...configuration import config
-from ...configuration.validation import MiscModel
+from ...configuration.validation import DefaultsModel
 from ...database.model import Node, Session, SessionNode, Tenant
 from ...database.types import NodeState
 from ...nodes_context import contextualize, decontextualize
@@ -41,9 +41,9 @@ SESSION_LIFETIME_MAX = None
 
 def _parse_lifetime_values():
     global SESSION_LIFETIME, SESSION_LIFETIME_MAX
-    misc = MiscModel(**config["misc"])
-    SESSION_LIFETIME = misc.session_lifetime
-    SESSION_LIFETIME_MAX = misc.session_lifetime_max
+    defaults = DefaultsModel(**config["defaults"])
+    SESSION_LIFETIME = defaults.session_lifetime
+    SESSION_LIFETIME_MAX = defaults.session_lifetime_max
 
 
 def session_lifetime():

--- a/duffy/app/controllers/tenant.py
+++ b/duffy/app/controllers/tenant.py
@@ -91,6 +91,8 @@ async def create_tenant(
         api_key=api_key,
         ssh_key=data.ssh_key.get_secret_value(),
         node_quota=data.node_quota,
+        session_lifetime=data.session_lifetime,
+        session_lifetime_max=data.session_lifetime_max,
     )
     db_async_session.add(created_tenant)
     try:
@@ -161,8 +163,16 @@ async def update_tenant(
                 updated_tenant.api_key = data.api_key
             api_key = SecretStr("this is hidden anyway")
 
-        if "node_quota" in data.dict(exclude_unset=True):
+        data_dict = data.dict(exclude_unset=True)
+
+        if "node_quota" in data_dict:
             updated_tenant.node_quota = data.node_quota
+
+        if "session_lifetime" in data_dict:
+            updated_tenant.session_lifetime = data.session_lifetime
+
+        if "session_lifetime_max" in data_dict:
+            updated_tenant.session_lifetime_max = data.session_lifetime_max
 
     api_tenant = TenantUpdateResultModel(
         api_key=api_key, **TenantModel.from_orm(updated_tenant).dict()

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -61,10 +61,10 @@ class DatabaseModel(ConfigBaseModel):
     sqlalchemy: SQLAlchemyModel
 
 
-class MiscModel(ConfigBaseModel):
+class DefaultsModel(ConfigBaseModel):
     session_lifetime: ConfigTimeDelta = Field(alias="session-lifetime")
     session_lifetime_max: ConfigTimeDelta = Field(alias="session-lifetime-max")
-    default_node_quota: conint(gt=0) = Field(alias="default-node-quota")
+    node_quota: conint(gt=0) = Field(alias="node-quota")
 
 
 class AnsibleMechanismPlaybookModel(ConfigBaseModel):
@@ -143,6 +143,6 @@ class ConfigModel(ConfigBaseModel):
     app: Optional[AppModel]
     tasks: Optional[TasksModel]
     database: Optional[DatabaseModel]
-    misc: Optional[MiscModel]
+    defaults: Optional[DefaultsModel]
     metaclient: Optional[LegacyModel]
     nodepools: Optional[NodePoolsRootModel]

--- a/duffy/database/model/tenant.py
+++ b/duffy/database/model/tenant.py
@@ -38,11 +38,11 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
         if self.node_quota is not None:
             return self.node_quota
 
-        return config["misc"]["default-node-quota"]
+        return config["defaults"]["node-quota"]
 
     @effective_node_quota.expression
     def effective_node_quota(cls):
         return case(
             [(cls.node_quota != None, cls.node_quota)],  # noqa: E711
-            else_=config["misc"]["default-node-quota"],
+            else_=config["defaults"]["node-quota"],
         )

--- a/duffy/database/model/tenant.py
+++ b/duffy/database/model/tenant.py
@@ -1,13 +1,20 @@
 import uuid
+from functools import lru_cache
 
 import bcrypt
-from sqlalchemy import Boolean, Column, Integer, Text, UnicodeText, text
+from sqlalchemy import Boolean, Column, Integer, Interval, Text, UnicodeText, text
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.sql import case
 
 from ...configuration import config
+from ...configuration.validation import DefaultsModel
 from .. import Base
 from ..util import CreatableMixin, RetirableMixin
+
+
+@lru_cache
+def _defaults_config():
+    return DefaultsModel(**config["defaults"])
 
 
 class Tenant(Base, CreatableMixin, RetirableMixin):
@@ -19,6 +26,8 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     ssh_key = Column(UnicodeText, nullable=False)
     _api_key = Column("api_key", Text, nullable=False)
     node_quota = Column(Integer, nullable=True)
+    session_lifetime = Column(Interval, nullable=True)
+    session_lifetime_max = Column(Interval, nullable=True)
 
     @hybrid_property
     def api_key(self):
@@ -44,5 +53,33 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     def effective_node_quota(cls):
         return case(
             [(cls.node_quota != None, cls.node_quota)],  # noqa: E711
-            else_=config["defaults"]["node-quota"],
+            else_=_defaults_config().node_quota,
+        )
+
+    @hybrid_property
+    def effective_session_lifetime(self):
+        if self.session_lifetime is not None:
+            return self.session_lifetime
+
+        return _defaults_config().session_lifetime
+
+    @effective_session_lifetime.expression
+    def effective_session_lifetime(cls):
+        return case(
+            [(cls.session_lifetime != None, cls.session_lifetime)],  # noqa: E711
+            else_=_defaults_config().session_lifetime,
+        )
+
+    @hybrid_property
+    def effective_session_lifetime_max(self):
+        if self.session_lifetime_max is not None:
+            return self.session_lifetime_max
+
+        return _defaults_config().session_lifetime_max
+
+    @effective_session_lifetime_max.expression
+    def effective_session_lifetime_max(cls):
+        return case(
+            [(cls.session_lifetime_max != None, cls.session_lifetime_max)],  # noqa: E711
+            else_=_defaults_config().session_lifetime_max,
         )

--- a/duffy/misc.py
+++ b/duffy/misc.py
@@ -1,5 +1,6 @@
 import re
 from datetime import timedelta
+from functools import lru_cache
 from typing import Type
 
 from pydantic.types import _registered
@@ -42,6 +43,7 @@ class _TimeDelta(timedelta):
             field_schema["examples"].append("-20m25s")
 
     @classmethod
+    @lru_cache
     def validate(cls, v):
         if isinstance(v, timedelta):
             return v

--- a/duffy/misc.py
+++ b/duffy/misc.py
@@ -43,11 +43,14 @@ class _TimeDelta(timedelta):
 
     @classmethod
     def validate(cls, v):
+        if isinstance(v, timedelta):
+            return v
+
         if cls.allow_dimensionless_seconds:
             if isinstance(v, int):
                 return timedelta(seconds=v)
             if not isinstance(v, str):
-                raise TypeError("input value must be a string or an integer")
+                raise TypeError(f"input value {v!r} must be a string or an integer")
             if v.isdigit():
                 return timedelta(seconds=int(v))
         elif not isinstance(v, str):

--- a/duffy/tasks/provision.py
+++ b/duffy/tasks/provision.py
@@ -263,7 +263,9 @@ def fill_pools(*, pool_names: Optional[List[str]] = None):
     else:
         unknown_pool_names = set(pool_names).difference(pool.name for pool in pools_to_process)
         if unknown_pool_names:
-            log.warn("fill_pools: unknown pool names, ignoring: %s", ", ".join(unknown_pool_names))
+            log.warning(
+                "fill_pools: unknown pool names, ignoring: %s", ", ".join(unknown_pool_names)
+            )
         pools_to_process = [pool for pool in pools_to_process if pool.name in pool_names]
 
     for pool in pools_to_process:

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -118,10 +118,10 @@ database:
     # the DB dialect must be async-compatible
     async_url: "sqlite+aiosqlite:///:memory:"
 
-misc:
+defaults:
   session-lifetime: "6h"
   session-lifetime-max: "12h"
-  default-node-quota: 10
+  node-quota: 10
 
 nodepools:
   abstract:

--- a/poetry.lock
+++ b/poetry.lock
@@ -1843,7 +1843,7 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "383240f90e69d28161f58d3acf63fa5f9220571c6a18c0fe829a36bc4b784eb2"
+content-hash = "0941071febf878392c507768156bd5642d7a7f438137c6e250bf4c03ff7166ea"
 
 [metadata.files]
 aiodns = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ jmespath = ">=0.10"
 poetry = "^1.1.13"
 pottery = "^3"
 pytest = ">=6.2.5"
-pytest-asyncio = ">=0.16"
+pytest-asyncio = ">=0.17"
 pytest-black = "^0.3.12"
 pytest-cov = "^3"
 pytest-flake8 = "^1.0.7"
@@ -91,6 +91,7 @@ legacy = ["httpx"]
 [tool.pytest.ini_options]
 addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --flake8 --isort"
 flake8-max-line-length = 100
+asyncio_mode = "auto"
 
 [tool.isort]
 line_length = 100

--- a/tests/app/controllers/__init__.py
+++ b/tests/app/controllers/__init__.py
@@ -12,7 +12,6 @@ from starlette.status import (
 from duffy.database.setup import _gen_test_api_key
 
 
-@pytest.mark.asyncio
 @pytest.mark.usefixtures(
     "db_sync_schema",
     "db_sync_model_initialized",

--- a/tests/app/controllers/test_session.py
+++ b/tests/app/controllers/test_session.py
@@ -134,7 +134,6 @@ class TestSession(BaseTestController):
 
 @pytest.mark.duffy_config(example_config=True)
 @pytest.mark.usefixtures("db_async_test_data", "db_async_model_initialized")
-@pytest.mark.asyncio
 class TestSessionWorkflow:
 
     path = "/api/v1/sessions"

--- a/tests/app/controllers/test_tenant.py
+++ b/tests/app/controllers/test_tenant.py
@@ -26,6 +26,8 @@ class TestTenant(BaseTestController):
         "name": "Some Honky Tenant!",
         "ssh_key": "# With a honky SSH key!",
         "node_quota": 5,
+        "session_lifetime": 60,
+        "session_lifetime_max": 120,
     }
     no_verify_attrs = ("ssh_key",)
     unique = "unique"
@@ -79,6 +81,10 @@ class TestTenant(BaseTestController):
             "success-reset-api-key",
             "success-update-node-quota",
             "success-unset-node-quota",
+            "success-update-session-lifetime",
+            "success-unset-session-lifetime",
+            "success-update-session-lifetime-max",
+            "success-unset-session-lifetime-max",
             "inactive",
             "not found",
             pytest.param("not admin", marks=pytest.mark.client_auth_as("tenant")),
@@ -125,8 +131,17 @@ class TestTenant(BaseTestController):
                 json_payload = {"api_key": "reset"}
             elif "update-node-quota" in testcase:
                 json_payload = {"node_quota": 20}
-            else:  # "unset-node-quota" in testcase
+            elif "unset-node-quota" in testcase:
                 json_payload = {"node_quota": None}
+            elif "update-session-lifetime-max" in testcase:
+                json_payload = {"session_lifetime_max": "2h"}
+            elif "unset-session-lifetime-max" in testcase:
+                json_payload = {"session_lifetime_max": None}
+            elif "update-session-lifetime" in testcase:
+                json_payload = {"session_lifetime": 3600}
+            else:  # "unset-session-lifetime" in testcase
+                json_payload = {"session_lifetime": None}
+
         else:
             # ensure the request body validates
             if "inactive" in testcase:
@@ -159,9 +174,19 @@ class TestTenant(BaseTestController):
                 assert result["tenant"]["node_quota"] == 20
             elif "unset-node-quota" in testcase:
                 assert result["tenant"]["node_quota"] is None
+            elif "update-session-lifetime-max" in testcase:
+                assert result["tenant"]["session_lifetime_max"] == 7200
+            elif "unset-session-lifetime-max" in testcase:
+                assert result["tenant"]["session_lifetime_max"] is None
+            elif "update-session-lifetime" in testcase:
+                assert result["tenant"]["session_lifetime"] == 3600
+            elif "unset-session-lifetime" in testcase:
+                assert result["tenant"]["session_lifetime"] is None
             else:
                 assert result["tenant"]["api_key"]
                 assert result["tenant"]["node_quota"] == 5
+                assert result["tenant"]["session_lifetime"] == 60
+                assert result["tenant"]["session_lifetime_max"] == 120
         elif testcase == "not admin":
             assert response.status_code == HTTP_403_FORBIDDEN
         elif testcase == "inactive":

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -22,7 +22,6 @@ from ..util import noop_context
         "authenticated-retired",
     ),
 )
-@pytest.mark.asyncio
 async def test__req_tenant_factory(testcase, db_async_session, db_async_test_data):
     if "unauthenticated" in testcase:
         credentials = None

--- a/tests/app/test_database.py
+++ b/tests/app/test_database.py
@@ -1,12 +1,9 @@
 from unittest import mock
 
-import pytest
-
 from duffy.app.database import req_db_async_session
 
 
 @mock.patch("duffy.app.database.async_session_maker")
-@pytest.mark.asyncio
 async def test_req_db_async_session(async_session_maker):
     mock_session = mock.MagicMock()
     mock_session.close = mock.AsyncMock()

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -10,7 +10,6 @@ from ..util import noop_context
 
 
 @pytest.mark.client_auth_as(None)
-@pytest.mark.asyncio
 class TestMain:
     api_paths = (
         "/api/v1/nodes",

--- a/tests/database/test_model.py
+++ b/tests/database/test_model.py
@@ -90,7 +90,7 @@ class TestTenant(ModelTestBase):
                 db_sync_obj.node_quota = 5
                 assert db_sync_obj.effective_node_quota == 5
             else:
-                config["misc"]["default-node-quota"] = sentinel = object()
+                config["defaults"]["node-quota"] = sentinel = object()
                 assert db_sync_obj.effective_node_quota is sentinel
 
     @pytest.mark.duffy_config(example_config=True, clear=True)
@@ -106,7 +106,7 @@ class TestTenant(ModelTestBase):
 
                 assert db_sync_obj in selected
             else:
-                config["misc"]["default-node-quota"] = 10
+                config["defaults"]["node-quota"] = 10
 
                 selected = db_sync_session.execute(
                     select(model.Tenant).filter(model.Tenant.effective_node_quota == 10)

--- a/tests/database/test_model.py
+++ b/tests/database/test_model.py
@@ -33,7 +33,6 @@ class ModelTestBase:
             if isinstance(objvalue, (int, str)):
                 assert objvalue == value
 
-    @pytest.mark.asyncio
     async def test_query_obj_async(self, db_async_obj, db_async_session):
         # The selectinload() option tells SQLAlchemy to load related objects and lazy loading breaks
         # things here. See here for details:
@@ -167,7 +166,6 @@ class TestNode(ModelTestBase):
         }
 
 
-@pytest.mark.asyncio
 class TestSessionNode(ModelTestBase):
     klass = model.SessionNode
     attrs = {"pool": "virtual-centos8stream-x86_64-small"}

--- a/tests/database/test_package.py
+++ b/tests/database/test_package.py
@@ -27,7 +27,6 @@ def test_init_sync_model(get_sync_engine, sync_session_maker):
     sync_session_maker.configure.assert_called_once_with(bind=sentinel)
 
 
-@pytest.mark.asyncio
 @pytest.mark.duffy_config(TEST_CONFIG)
 @mock.patch("duffy.database.async_session_maker", new_callable=mock.AsyncMock)
 @mock.patch("duffy.database.get_async_engine")
@@ -43,7 +42,6 @@ async def test_init_async_model(get_async_engine, async_session_maker):
     async_session_maker.configure.assert_called_once_with(bind=sentinel)
 
 
-@pytest.mark.asyncio
 @mock.patch("duffy.database.init_async_model")
 @mock.patch("duffy.database.init_sync_model")
 def test_init_model(init_sync_model, init_async_model):

--- a/tests/fixtures/test_db_test_data.py
+++ b/tests/fixtures/test_db_test_data.py
@@ -14,7 +14,6 @@ def test_objs_sync(obj_class, db_sync_test_data, db_sync_session):
 
 
 @pytest.mark.parametrize("obj_class", obj_classes)
-@pytest.mark.asyncio
 async def test_objs_async(obj_class, db_async_test_data, db_async_session):
     results = await db_async_session.execute(select(obj_class))
     objects = results.all()

--- a/tests/tasks/test_provision.py
+++ b/tests/tasks/test_provision.py
@@ -205,19 +205,19 @@ def test_provision_nodes_into_pool(reuse_nodes, testcase, foo_pool, db_sync_sess
         args, kwargs = pool_provision.call_args
         (nodes_in_call,) = args
         assert len(kwargs) == 0
-        if "invalid-node-results" in testcase or "fewer-provisions" in testcase:
-            assert nodes_in_call
-            assert {node.id for node in nodes_in_call} > node_ids
-            assert 0 < _node_lookup_hostname_from_ipaddr.await_count <= len(nodes) // 2
-            if reuse_nodes:
-                assert "[foo] Returning 2 left-over reusable node(s)" in caplog.messages
-            else:
-                assert "[foo] Cleaning up 2 left-over preallocated node(s)" in caplog.messages
-        else:
-            assert {node.id for node in nodes_in_call} == node_ids
-            _node_lookup_hostname_from_ipaddr.await_count = len(nodes) // 2
-
         if "real-playbook" not in testcase:
+            if "invalid-node-results" in testcase or "fewer-provisions" in testcase:
+                assert nodes_in_call
+                assert {node.id for node in nodes_in_call} > node_ids
+                assert 0 < _node_lookup_hostname_from_ipaddr.await_count <= len(nodes) // 2
+                if reuse_nodes:
+                    assert "[foo] Returning 2 left-over reusable node(s)" in caplog.messages
+                else:
+                    assert "[foo] Cleaning up 2 left-over preallocated node(s)" in caplog.messages
+            else:
+                assert {node.id for node in nodes_in_call} == node_ids
+                assert _node_lookup_hostname_from_ipaddr.await_count == len(nodes) // 2
+
             assert any(node.hostname.startswith("looked-up-node") for node in nodes)
             assert any(node.hostname.startswith("playbook-node") for node in nodes)
 

--- a/tests/tasks/test_provision.py
+++ b/tests/tasks/test_provision.py
@@ -46,7 +46,6 @@ def _gen_provision_nodes_into_pool_param_combinations():
     ]
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("testcase", ("success", "success-no-name", "failure"))
 @mock.patch("duffy.tasks.provision.aiodns")
 async def test__node_lookup_hostname_from_ipaddr(aiodns, testcase):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -51,7 +51,6 @@ class TestAdminContext:
         else:
             assert "Configuration key missing or wrong: BOO" in caplog.text
 
-    @pytest.mark.asyncio
     @pytest.mark.parametrize("testcase", ("success", "exception"))
     @mock.patch("duffy.admin.async_session_maker")
     async def test_proxy_controller_function_async(self, async_session_maker, testcase, admin_ctx):

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -118,17 +118,33 @@ class TestAdminContext:
         get_tenant_id.assert_called_once_with("name")
         proxy_controller_function.assert_called_once_with(controllers.tenant.get_tenant, id=6)
 
-    @pytest.mark.parametrize("testcase", ("normal", "normal-with-quota", "is-admin"))
+    @pytest.mark.parametrize(
+        "testcase",
+        (
+            "normal",
+            "normal-with-quota",
+            "normal-with-session-lifetime",
+            "normal-with-session-lifetime-max",
+            "is-admin",
+        ),
+    )
     @mock.patch.object(AdminContext, "proxy_controller_function")
     def test_create_tenant(self, proxy_controller_function, testcase, admin_ctx):
         is_admin = testcase == "is-admin"
         with_quota = "with-quota" in testcase
         node_quota = 5 if with_quota else None
+        session_lifetime = 3600 if "with-session-lifetime" in testcase else None
+        session_lifetime_max = 7200 if "with-session-lifetime-max" in testcase else None
 
         proxy_controller_function.return_value = sentinel = object()
 
         result = admin_ctx.create_tenant(
-            name="name", ssh_key="# no ssh key", node_quota=node_quota, is_admin=is_admin
+            name="name",
+            ssh_key="# no ssh key",
+            node_quota=node_quota,
+            session_lifetime=session_lifetime,
+            session_lifetime_max=session_lifetime_max,
+            is_admin=is_admin,
         )
 
         assert result == sentinel
@@ -136,7 +152,12 @@ class TestAdminContext:
         proxy_controller_function.assert_called_once_with(
             controllers.tenant.create_tenant,
             data=api_models.TenantCreateModel(
-                name="name", ssh_key="# no ssh key", node_quota=node_quota, is_admin=is_admin
+                name="name",
+                ssh_key="# no ssh key",
+                node_quota=node_quota,
+                session_lifetime=session_lifetime,
+                session_lifetime_max=session_lifetime_max,
+                is_admin=is_admin,
             ),
         )
 

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -44,7 +44,6 @@ class TestAuth:
             "authenticated-retired",
         ),
     )
-    @pytest.mark.asyncio
     async def test__req_credentials_factory(self, testcase):
         if "unauthenticated" in testcase:
             password = None
@@ -84,7 +83,6 @@ class TestAuth:
                 assert password is None
 
 
-@pytest.mark.asyncio
 @pytest.mark.duffy_config(example_config=True)
 class TestMain:
     apiv1_result = {

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -39,6 +39,7 @@ class TestAPITimeDelta(_BaseTestTimeDelta):
     cls_to_test = APITimeDelta
 
     input_to_expected = {
+        timedelta(minutes=5): timedelta(minutes=5),
         "+3h30m": timedelta(hours=3, minutes=30),
         "-2d": timedelta(days=-2),
         "300": ValueError,
@@ -59,6 +60,7 @@ class TestConfigTimeDelta(_BaseTestTimeDelta):
     cls_to_test = ConfigTimeDelta
 
     input_to_expected = {
+        timedelta(minutes=5): timedelta(minutes=5),
         "+3h30m": timedelta(hours=3, minutes=30),
         "1h": timedelta(hours=1),
         "300": timedelta(minutes=5),

--- a/tests/test_nodes_context.py
+++ b/tests/test_nodes_context.py
@@ -6,7 +6,6 @@ import pytest
 from duffy import nodes_context
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("with_stdin", (True, False))
 @pytest.mark.parametrize("success", (True, False))
 @mock.patch("asyncio.create_subprocess_exec")
@@ -45,7 +44,6 @@ async def test_run_remote_cmd(create_subprocess_exec, success, with_stdin):
         assert result is None
 
 
-@pytest.mark.asyncio
 @mock.patch("duffy.nodes_context.run_remote_cmd")
 async def test_decontextualize_one(run_remote_cmd):
     run_remote_cmd.return_value = sentinel = object()
@@ -58,7 +56,6 @@ async def test_decontextualize_one(run_remote_cmd):
     assert result == sentinel
 
 
-@pytest.mark.asyncio
 @mock.patch("duffy.nodes_context.decontextualize_one")
 async def test_decontextualize(decontextualize_one):
     nodes = [f"node{idx}.domain.tld" for idx in range(1, 6)]
@@ -71,7 +68,6 @@ async def test_decontextualize(decontextualize_one):
     decontextualize_one.assert_has_awaits(mock.call(node=node) for node in nodes)
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize("decontextualize_fail", (False, True))
 @mock.patch("duffy.nodes_context.run_remote_cmd")
 @mock.patch("duffy.nodes_context.decontextualize_one")
@@ -100,7 +96,6 @@ async def test_contextualize_one(decontextualize_one, run_remote_cmd, decontextu
         assert result is None
 
 
-@pytest.mark.asyncio
 @mock.patch("duffy.nodes_context.contextualize_one")
 async def test_contextualize(contextualize_one):
     nodes = [f"node{idx}.domain.tld" for idx in range(1, 6)]


### PR DESCRIPTION
```
commit 3672733b33e78f3f7eb5e822f51657f2d4bef640
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 9 12:47:48 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Configure pytest-asyncio asyncio_mode to `auto`
    
    Remove explicit @pytest.mark.asyncio decorators, as this pytest-asyncio
    mode doesn't require it. This gets rid of a couple of warnings where the
    decorator applied to a whole class with some non-async methods.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit e914fd1bbf7e8d0ccc26301c80b257f4fc24258d
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 9 14:10:36 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Wrap coroutines in tasks for asyncio.wait()
    
    Doing this implicitly is deprecated and will go away in Python 3.11.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit dbc598b45d6b42f1fef9b940df9acb5fcfabd353
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 9 14:11:36 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Use log.warning() instead of deprecated log.warn()
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 6409c2861fcb77323106100e97e35cc0ee0e37e7
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 9 14:12:05 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Fix testing hostname lookup in success cases
    
    Parts of this test were non-functional before which hid that they were
    erroneously executed in the case of real playbooks (to which they don't
    apply).
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit e4b51e0482f75aa7fbb4935118202ee8c09c5781
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 9 11:31:31 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Rename `misc` to `defaults` in configuration
    
    This describes better of what is configured in the section and prepares
    for per tenant session lifetimes.
    
    Related: #384
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit d02f97beab0d5953c37285f7c5baa6b2e6bb4b03
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Tue May 10 11:13:19 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Accept timedelta values for TimeDelta validation
    
    This is to better support the admin CLI which converts these values
    upfront.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 66a39f20668e770bd3a3530daa158086a4e685d8
Author:     Nils Philippsen <nils@redhat.com>
AuthorDate: Mon May 9 11:16:46 2022 +0200
Commit:     Nils Philippsen <nils@redhat.com>
CommitDate: Tue May 10 11:16:52 2022 +0200

    Implement per tenant session lifetimes
    
    Previously, this was configured globally. Now, operators set a default
    value in configuration but can set individual session_lifetime and
    session_lifetime_max values for tenants.
    
    Fixes: #384
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```