### PR TITLE
Don't let Alembic trip over unquoted percent signs

### DIFF
--- a/duffy/database/migrations/main.py
+++ b/duffy/database/migrations/main.py
@@ -18,9 +18,9 @@ class AlembicMigration:
     def config(self):
         if not hasattr(self, "_config"):
             self._config = alembic.config.Config()
-            self._config.set_main_option("script_location", str(HERE.absolute()))
+            self._config.set_main_option("script_location", str(HERE.absolute()).replace("%", "%%"))
             self._config.set_main_option(
-                "sqlalchemy.url", config["database"]["sqlalchemy"]["sync_url"]
+                "sqlalchemy.url", config["database"]["sqlalchemy"]["sync_url"].replace("%", "%%")
             )
         return self._config
 


### PR DESCRIPTION
Alembic uses configparser for its configuration. Percent signs need to
be doubled there, otherwise it will interpret them as printf-style
placeholders and attempt to interpolate them (which fails).

Fixes: #393

Signed-off-by: Nils Philippsen <nils@redhat.com>