### PR TITLE
Add `duffy client` command

### DIFF
--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -183,10 +183,10 @@ def migration_downgrade(version):
     alembic_migration.downgrade(version)
 
 
-# Interactive shell
+# Interactive development/debugging shell
 
 
-@cli.command(name="shell")
+@cli.command(name="dev-shell")
 @click.option(
     "-t",
     "--shell-type",
@@ -194,7 +194,7 @@ def migration_downgrade(version):
     help="Type of interactive shell to use.",
     default=None,
 )
-def run_shell(shell_type: str):
+def dev_shell(shell_type: str):
     """Run an interactive shell."""
     try:
         database.init_model()

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -15,7 +15,11 @@ from .database.migrations.main import alembic_migration
 from .database.setup import setup_db_schema, setup_db_test_data
 from .exceptions import DuffyConfigurationError
 from .misc import ConfigTimeDelta
-from .tasks import start_worker
+
+try:
+    from .tasks import start_worker
+except ImportError:  # pragma: no cover
+    start_worker = None
 from .util import UNSET, SentinelType
 from .version import __version__
 
@@ -237,7 +241,10 @@ def dev_shell(shell_type: str):
 @click.argument("worker_args", nargs=-1, type=click.UNPROCESSED)
 def worker(worker_args: Tuple[str]):
     """Start a Celery worker to process backend tasks."""
-    start_worker(worker_args=worker_args)
+    if start_worker:
+        start_worker(worker_args=worker_args)
+    else:
+        raise click.ClickException("Please install the duffy[tasks] extra for this command")
 
 
 # Run the web app

--- a/duffy/client/__init__.py
+++ b/duffy/client/__init__.py
@@ -1,0 +1,2 @@
+from .formatter import DuffyFormatter  # noqa: F401
+from .main import DuffyClient  # noqa: F401

--- a/duffy/client/formatter.py
+++ b/duffy/client/formatter.py
@@ -1,0 +1,92 @@
+import json
+import shlex
+from typing import Generator
+
+import yaml
+from pydantic import BaseModel
+
+from ..api_models import SessionModel, SessionResult, SessionResultCollection
+from .main import DuffyAPIErrorModel
+
+
+class DuffyFormatter:
+    _subclasses_for_format = {}
+
+    def __init_subclass__(cls, format, **kwargs):
+        cls._subclasses_for_format[format] = cls
+
+    @classmethod
+    def new_for_format(cls, format, *args, **kwargs):
+        return cls._subclasses_for_format[format](*args, **kwargs)
+
+    @staticmethod
+    def result_as_compatible_dict(result: BaseModel) -> dict:
+        return json.loads(result.json())
+
+    def format(self, result: BaseModel) -> str:
+        raise NotImplementedError()
+
+
+class DuffyJSONFormatter(DuffyFormatter, format="json"):
+    def format(self, result: BaseModel) -> str:
+        return result.json(indent=2)
+
+
+class DuffyYAMLFormatter(DuffyFormatter, format="yaml"):
+    def format(self, result: BaseModel) -> str:
+        return yaml.dump(self.result_as_compatible_dict(result))
+
+
+class DuffyFlatFormatter(DuffyFormatter, format="flat"):
+    model_to_flattener = {
+        DuffyAPIErrorModel: "flatten_api_error",
+        SessionResult: "flatten_session_result",
+        SessionResultCollection: "flatten_sessions_result",
+    }
+
+    @staticmethod
+    def format_key_value(key, value):
+        if value is None:
+            value = ""
+        elif isinstance(value, bool):
+            value = "TRUE" if value else "FALSE"
+        elif isinstance(value, (int, float)):
+            pass
+        else:
+            value = shlex.quote(str(value))
+            if value[:1] != "'":
+                value = f"'{value}'"
+
+        return f"{key}={value}"
+
+    def flatten_api_error(self, api_error: DuffyAPIErrorModel) -> Generator[str, None, None]:
+        yield self.format_key_value("error", api_error.error.detail)
+
+    def flatten_session(self, session: SessionModel) -> Generator[str, None, None]:
+        for node in sorted(session.nodes, key=lambda node: (node.pool, node.hostname, node.ipaddr)):
+            fields = {
+                "session_id": session.id,
+                "active": session.active,
+                "created_at": session.created_at,
+                "retired_at": session.retired_at,
+                "pool": node.pool,
+                "hostname": node.hostname,
+                "ipaddr": node.ipaddr,
+            }
+            yield " ".join(self.format_key_value(key, value) for key, value in fields.items())
+
+    def flatten_session_result(self, result: SessionResult) -> Generator[str, None, None]:
+        yield from self.flatten_session(result.session)
+
+    def flatten_sessions_result(
+        self, result: SessionResultCollection
+    ) -> Generator[str, None, None]:
+        for session in result.sessions:
+            yield from self.flatten_session(session)
+
+    def format(self, result: BaseModel) -> str:
+        for model, flattener in self.model_to_flattener.items():
+            if isinstance(result, model):
+                return "\n".join(getattr(self, flattener)(result))
+
+        raise TypeError("Can't flatten {result!r}")

--- a/duffy/client/main.py
+++ b/duffy/client/main.py
@@ -1,0 +1,137 @@
+from enum import Enum
+from http import HTTPStatus
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import httpx
+from pydantic import BaseModel
+
+from ..api_models import (
+    SessionCreateModel,
+    SessionResult,
+    SessionResultCollection,
+    SessionUpdateModel,
+)
+from ..configuration import config
+
+
+class _MethodEnum(str, Enum):
+    get = "get"
+    post = "post"
+    put = "put"
+    delete = "delete"
+
+
+class DuffyApiErrorDetailModel(BaseModel):
+    detail: str
+
+    class Config:
+        extra = "allow"
+
+
+class DuffyAPIErrorModel(BaseModel):
+    error: DuffyApiErrorDetailModel
+
+
+class DuffyClient:
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        auth_name: Optional[str] = None,
+        auth_key: Optional[str] = None,
+    ):
+        if url:
+            self.url = url
+        if auth_name:
+            self.auth_name = auth_name
+        if auth_key:
+            self.auth_key = auth_key
+
+    @property
+    def url(self):
+        return getattr(self, "_url", config["client"]["url"])
+
+    @url.setter
+    def url(self, value):
+        self._url = value
+
+    @property
+    def auth_name(self):
+        return getattr(self, "_auth_name", config["client"]["auth"]["name"])
+
+    @auth_name.setter
+    def auth_name(self, value):
+        self._auth_name = value
+
+    @property
+    def auth_key(self):
+        return getattr(self, "_auth_key", config["client"]["auth"]["key"])
+
+    @auth_key.setter
+    def auth_key(self, value):
+        self._auth_key = value
+
+    def client(self):
+        return httpx.Client(auth=(self.auth_name, self.auth_key), base_url=config["client"]["url"])
+
+    def _query_method(
+        self,
+        method: _MethodEnum,
+        url: str,
+        *,
+        in_dict: Optional[Dict[str, Any]] = None,
+        in_model: Optional[BaseModel] = None,
+        out_model: BaseModel,
+        expected_status: Union[HTTPStatus, Sequence[HTTPStatus]] = HTTPStatus.OK,
+    ) -> BaseModel:
+        add_kwargs = {}
+        if in_dict is not None:
+            add_kwargs["json"] = in_model(**in_dict).dict()
+
+        with self.client() as client:
+            client_method = getattr(client, method.name)
+            response = client_method(url=url, **add_kwargs)
+
+        if isinstance(expected_status, HTTPStatus):
+            expected_status = (expected_status,)
+
+        if response.status_code not in expected_status:
+            try:
+                return DuffyAPIErrorModel(error=response.json())
+            except Exception as exc:
+                response.raise_for_status()
+                raise RuntimeError(f"Can't process response: {response}") from exc
+
+        return out_model(**response.json())
+
+    def list_sessions(self) -> SessionResultCollection:
+        return self._query_method(
+            _MethodEnum.get,
+            "/sessions",
+            out_model=SessionResultCollection,
+        )
+
+    def show_session(self, session_id: int) -> SessionResult:
+        return self._query_method(
+            _MethodEnum.get,
+            f"/sessions/{session_id}",
+            out_model=SessionResult,
+        )
+
+    def request_session(self, nodes_specs: List[Dict[str, str]]) -> SessionResult:
+        return self._query_method(
+            _MethodEnum.post,
+            "/sessions",
+            in_dict={"nodes_specs": nodes_specs},
+            in_model=SessionCreateModel,
+            out_model=SessionResult,
+            expected_status=HTTPStatus.CREATED,
+        )
+
+    def retire_session(self, session_id: int) -> SessionResult:
+        return self._query_method(
+            _MethodEnum.put,
+            f"/sessions/{session_id}",
+            in_dict={"active": False},
+            in_model=SessionUpdateModel,
+            out_model=SessionResult,
+        )

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -3,7 +3,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 
-from pydantic import AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl, validator
+from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl, validator
 
 from ..misc import ConfigTimeDelta
 
@@ -132,7 +132,7 @@ class LegacyPoolMapModel(ConfigBaseModel):
 class LegacyModel(ConfigBaseModel):
     host: Optional[str]
     port: Optional[conint(gt=0, lt=65536)]
-    dest: Optional[str]
+    dest: Optional[AnyHttpUrl]
     loglevel: Optional[LogLevel]
     logging: Optional[LoggingModel]
     usermap: Dict[str, str]

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -2,6 +2,7 @@ import re
 from enum import Enum
 from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
+from uuid import UUID
 
 from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl, validator
 
@@ -109,6 +110,16 @@ class LoggingModel(ConfigBaseModel):
         extra = "allow"
 
 
+class ClientAuthModel(ConfigBaseModel):
+    name: str
+    key: UUID
+
+
+class ClientModel(ConfigBaseModel):
+    url: AnyHttpUrl
+    auth: ClientAuthModel
+
+
 class AppModel(ConfigBaseModel):
     loglevel: Optional[LogLevel]
     host: Optional[str]
@@ -140,6 +151,7 @@ class LegacyModel(ConfigBaseModel):
 
 
 class ConfigModel(ConfigBaseModel):
+    client: Optional[ClientModel]
     app: Optional[AppModel]
     tasks: Optional[TasksModel]
     database: Optional[DatabaseModel]

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -1,4 +1,10 @@
 ---
+client:
+  url: http://127.0.0.1:8080/api/v1
+  auth:
+    name: tenant
+    key: a8b9899d-b128-59a1-aa86-754920b7f5ed
+
 app:
   loglevel: warning
   host: 0.0.0.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -1835,6 +1835,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [extras]
 all = ["ipython", "psycopg2", "asyncpg", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "httpx"]
+client = ["httpx"]
 devshell = ["ipython"]
 legacy = ["httpx"]
 postgresql = ["psycopg2", "asyncpg"]
@@ -1843,7 +1844,7 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "50256e78921be19f08f15889fb282155478c8a1fa23f23f845e9fae16c117237"
+content-hash = "dd04e853ab17aa408cebfa8824b7dc08274c665ae56fd3e243e446b32935135b"
 
 [metadata.files]
 aiodns = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1835,7 +1835,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 
 [extras]
 all = ["ipython", "psycopg2", "asyncpg", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "httpx"]
-interactive = ["ipython"]
+devshell = ["ipython"]
 legacy = ["httpx"]
 postgresql = ["psycopg2", "asyncpg"]
 tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
@@ -1843,7 +1843,7 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "0941071febf878392c507768156bd5642d7a7f438137c6e250bf4c03ff7166ea"
+content-hash = "50256e78921be19f08f15889fb282155478c8a1fa23f23f845e9fae16c117237"
 
 [metadata.files]
 aiodns = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -25,7 +25,7 @@ name = "alembic"
 version = "1.8.0"
 description = "A database migration tool for SQLAlchemy."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -120,7 +120,7 @@ name = "asgiref"
 version = "3.5.2"
 description = "ASGI specs, helper code, and adapters"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -204,7 +204,7 @@ name = "bcrypt"
 version = "3.2.2"
 description = "Modern password hashing for your software and your servers"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -752,7 +752,7 @@ name = "importlib-resources"
 version = "5.7.1"
 description = "Read resources from Python packages"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -935,7 +935,7 @@ name = "mako"
 version = "1.2.0"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1749,7 +1749,7 @@ name = "uvicorn"
 version = "0.17.6"
 description = "The lightning-fast ASGI server."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1834,17 +1834,18 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["ipython", "psycopg2", "asyncpg", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "httpx"]
+all = ["SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "ipython", "psycopg2", "asyncpg", "httpx"]
+app = ["SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 client = ["httpx"]
 devshell = ["ipython"]
-legacy = ["httpx"]
+legacy = ["httpx", "Jinja2"]
 postgresql = ["psycopg2", "asyncpg"]
 tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "dd04e853ab17aa408cebfa8824b7dc08274c665ae56fd3e243e446b32935135b"
+content-hash = "6a63f0ac4b81bb65905e145b7537e245cfcbc3be3623a13e170584b18fa3b5c1"
 
 [metadata.files]
 aiodns = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,12 +37,12 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.8"
 PyYAML = "^6"
-SQLAlchemy = {version = "^1.4.25", extras=["asyncio"]}
-alembic = "^1.7.5"
-bcrypt = "^3.2"
+SQLAlchemy = {version = "^1.4.25", extras=["asyncio"], optional = true}
+alembic = {version = "^1.7.5", optional = true}
+bcrypt = {version = "^3.2", optional = true}
 click = "^8.0.3"
-fastapi = ">=0.70"
-uvicorn = ">=0.15"
+fastapi = {version = ">=0.70", optional = true}
+uvicorn = {version = ">=0.15", optional = true}
 Jinja2 = {version = "^3.0.3", optional = true}
 ansible-runner = {version = "^2.1.1", optional = true}
 asyncpg = {version = "^0.25", optional = true}
@@ -78,15 +78,27 @@ tox = "^3.24.4"
 [tool.poetry.extras]
 # keep this in sync with the real extras
 all = [
+    "SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn",
+    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery",
     "ipython",
     "psycopg2", "asyncpg",
-    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery",
     "httpx",
 ]
+
+# the `serve` command
+app = [
+    "SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn",
+    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery",
+]
+# the `dev-shell` command
 devshell = ["ipython"]
+# the `serve`, `worker` and `dev-shell` commands if you use PostgreSQL
 postgresql = ["psycopg2", "asyncpg"]
+# the `worker` command
 tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
-legacy = ["httpx"]
+# the `serve-legacy` command
+legacy = ["httpx", "Jinja2"]
+# the `client ...` commands
 client = ["httpx"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ all = [
     "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery",
     "httpx",
 ]
-interactive = ["ipython"]
+devshell = ["ipython"]
 postgresql = ["psycopg2", "asyncpg"]
 tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 legacy = ["httpx"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ devshell = ["ipython"]
 postgresql = ["psycopg2", "asyncpg"]
 tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
 legacy = ["httpx"]
+client = ["httpx"]
 
 [tool.pytest.ini_options]
 addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --flake8 --isort"

--- a/tests/client/test_formatters.py
+++ b/tests/client/test_formatters.py
@@ -1,0 +1,172 @@
+import datetime as dt
+import json
+from enum import Enum
+
+import pytest
+from pydantic import BaseModel
+
+from duffy.api_models import (
+    SessionModel,
+    SessionNodeModel,
+    SessionResult,
+    SessionResultCollection,
+    TenantModel,
+)
+from duffy.client.formatter import (
+    DuffyFlatFormatter,
+    DuffyFormatter,
+    DuffyJSONFormatter,
+    DuffyYAMLFormatter,
+)
+from duffy.client.main import DuffyAPIErrorModel
+
+from ..util import noop_context
+
+
+class _TestEnum(str, Enum):
+    bar = "bar"
+
+
+class _TestModel(BaseModel):
+    test_enum: _TestEnum
+
+
+TEST_MODEL_DICT = {"test_enum": _TestEnum.bar}
+
+
+class TestDuffyFormatter:
+    @pytest.mark.parametrize(
+        "format, formatter_cls",
+        (
+            ("json", DuffyJSONFormatter),
+            ("yaml", DuffyYAMLFormatter),
+            ("flat", DuffyFlatFormatter),
+        ),
+    )
+    def test_new_for_format(self, format, formatter_cls):
+        fmtobj = DuffyFormatter.new_for_format(format)
+        assert isinstance(fmtobj, formatter_cls)
+
+    def test_result_as_compatible_dict(self):
+        result = _TestModel(test_enum=_TestEnum.bar)
+
+        assert DuffyFormatter.result_as_compatible_dict(result) == {"test_enum": "bar"}
+
+    def test_format(self):
+        with pytest.raises(NotImplementedError):
+            DuffyFormatter().format(_TestModel(test_enum=_TestEnum.bar))
+
+
+class TestDuffyJSONFormatter:
+    def test_format(self):
+        formatted = DuffyJSONFormatter().format(_TestModel(**TEST_MODEL_DICT))
+        assert json.loads(formatted) == TEST_MODEL_DICT
+
+
+class TestDuffyYAMLFormatter:
+    def test_format(self):
+        formatted = DuffyYAMLFormatter().format(_TestModel(**TEST_MODEL_DICT))
+        assert formatted == "test_enum: bar\n"
+
+
+class TestDuffyFlatFormatter:
+    CREATED_AT = dt.datetime(year=2022, month=5, day=31, hour=12, minute=0, second=0)
+    TEST_SESSION = SessionModel(
+        id=17,
+        active=True,
+        created_at=CREATED_AT,
+        retired_at=None,
+        tenant=TenantModel(
+            id=1,
+            active=True,
+            created_at=CREATED_AT,
+            name="tenant",
+            ssh_key="foo",
+            effective_node_quota=10,
+            effective_session_lifetime=dt.timedelta(hours=6),
+            effective_session_lifetime_max=dt.timedelta(hours=12),
+        ),
+        data={},
+        nodes=[
+            SessionNodeModel(
+                id=32,
+                hostname="hostname",
+                ipaddr="127.0.0.1",
+                pool="pool",
+                reusable=True,
+                data={},
+            ),
+        ],
+    )
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        (
+            (None, ""),
+            (True, "TRUE"),
+            (False, "FALSE"),
+            (5, 5),
+            (5.5, 5.5),
+            ("abc", "'abc'"),
+            ("ab'cd", "'ab'\"'\"'cd'"),
+        ),
+    )
+    def test_format_key_value(self, value, expected):
+        assert DuffyFlatFormatter.format_key_value("boo", value) == f"boo={expected}"
+
+    def test_flatten_api_error(self):
+        api_error = DuffyAPIErrorModel(error={"detail": "Hullo."})
+        node_line = next(DuffyFlatFormatter().flatten_api_error(api_error=api_error))
+        assert node_line == "error='Hullo.'"
+
+    def test_flatten_session(self):
+        node_line = next(DuffyFlatFormatter().flatten_session(session=self.TEST_SESSION))
+
+        assert node_line == (
+            "session_id=17 active=TRUE created_at='2022-05-31 12:00:00' retired_at= pool='pool'"
+            " hostname='hostname' ipaddr='127.0.0.1'"
+        )
+
+    def test_flatten_session_result(self):
+        node_line = next(
+            DuffyFlatFormatter().flatten_session_result(
+                SessionResult(action="get", session=self.TEST_SESSION)
+            )
+        )
+
+        assert node_line == (
+            "session_id=17 active=TRUE created_at='2022-05-31 12:00:00' retired_at= pool='pool'"
+            " hostname='hostname' ipaddr='127.0.0.1'"
+        )
+
+    def test_flatten_sessions_result(self):
+        node_line = next(
+            DuffyFlatFormatter().flatten_sessions_result(
+                SessionResultCollection(action="get", sessions=[self.TEST_SESSION])
+            )
+        )
+
+        assert node_line == (
+            "session_id=17 active=TRUE created_at='2022-05-31 12:00:00' retired_at= pool='pool'"
+            " hostname='hostname' ipaddr='127.0.0.1'"
+        )
+
+    @pytest.mark.parametrize("result_cls", (SessionResult, SessionResultCollection, dict))
+    def test_format(self, result_cls):
+        expectation = noop_context()
+        if result_cls == SessionResult:
+            api_result = SessionResult(action="get", session=self.TEST_SESSION)
+        elif result_cls == SessionResultCollection:
+            api_result = SessionResultCollection(action="get", sessions=[self.TEST_SESSION])
+        else:
+            api_result = {"a dict": "contents don't matter"}
+            expectation = pytest.raises(TypeError)
+
+        with expectation:
+            formatted = DuffyFlatFormatter().format(api_result)
+
+        if result_cls in (SessionResult, SessionResultCollection):
+            assert formatted == (
+                "session_id=17 active=TRUE created_at='2022-05-31 12:00:00' retired_at= pool='pool'"
+                " hostname='hostname' ipaddr='127.0.0.1'"
+            )

--- a/tests/client/test_main.py
+++ b/tests/client/test_main.py
@@ -1,0 +1,164 @@
+from http import HTTPStatus
+from json import JSONDecodeError
+from unittest import mock
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from duffy.api_models import (
+    SessionCreateModel,
+    SessionResult,
+    SessionResultCollection,
+    SessionUpdateModel,
+)
+from duffy.client import DuffyClient
+from duffy.client.main import _MethodEnum
+from duffy.configuration import config
+
+from ..util import noop_context
+
+
+class InModel(BaseModel):
+    in_field: int
+
+
+class OutModel(BaseModel):
+    out_field: int
+
+
+@pytest.mark.duffy_config(example_config=True)
+class TestDuffyClient:
+    @pytest.mark.parametrize("testcase", ("params-set", "params-unset"))
+    def test___init___and_properties(self, testcase):
+        if testcase == "params-set":
+            kwargs = {
+                "url": "http://localhost:6789",
+                "auth_name": "Bonzo the Clown",
+                "auth_key": "🔑",
+            }
+        else:
+            kwargs = {}
+
+        client = DuffyClient(**kwargs)
+
+        if testcase == "params-set":
+            for key, value in kwargs.items():
+                assert getattr(client, key) == value
+        else:
+            assert client.url == config["client"]["url"]
+            assert client.auth_name == config["client"]["auth"]["name"]
+            assert client.auth_key == config["client"]["auth"]["key"]
+
+    def test_client_property(self):
+        client = DuffyClient().client()
+
+        assert isinstance(client, httpx.Client)
+        assert isinstance(client.auth, httpx.BasicAuth)
+        url = config["client"]["url"]
+        if not url.endswith("/"):
+            url += "/"
+        assert client.base_url == httpx.URL(url)
+
+    @pytest.mark.parametrize(
+        "actual_status, with_detail",
+        (
+            (HTTPStatus.OK, None),
+            (HTTPStatus.CREATED, None),
+            (HTTPStatus.BAD_REQUEST, True),
+            (HTTPStatus.BAD_REQUEST, False),
+        ),
+    )
+    @pytest.mark.parametrize("expected_status", (HTTPStatus.OK, (HTTPStatus.OK,)))
+    @pytest.mark.parametrize("http_method", ("get", "post", "put"))
+    @mock.patch("duffy.client.main.httpx.Client")
+    def test__query_method(self, Client, http_method, expected_status, actual_status, with_detail):
+        method = _MethodEnum(http_method)
+
+        expected_statuses = (
+            (expected_status,) if isinstance(expected_status, HTTPStatus) else expected_status
+        )
+
+        Client.return_value = ctxmgr = mock.MagicMock()
+        ctxmgr.__enter__.return_value = apiv1_client = mock.MagicMock()
+
+        expectation = noop_context()
+
+        getattr(apiv1_client, http_method).return_value = apiv1_response = mock.MagicMock()
+        apiv1_response.status_code = actual_status
+        if actual_status in expected_statuses:
+            apiv1_response.json.return_value = {"out_field": 7}
+        elif with_detail:
+            apiv1_response.json.return_value = {"detail": "a detail"}
+        elif actual_status >= 400:  # client- and server-side errors
+            apiv1_response.json.side_effect = JSONDecodeError("msg", "doc", 0)
+            request = mock.MagicMock()
+            apiv1_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                message="BOOP", request=request, response=apiv1_response
+            )
+            expectation = pytest.raises(httpx.HTTPStatusError)
+        else:  # unexpected, successful response
+            apiv1_response.json.return_value = {"another_out_field": 15}
+            expectation = pytest.raises(RuntimeError)
+
+        kwargs = {"expected_status": expected_status}
+
+        if http_method in ("post", "put"):
+            kwargs.update({"in_dict": {"in_field": 5}, "in_model": InModel})
+
+        dclient = DuffyClient()
+
+        with expectation as exc:
+            result = dclient._query_method(method=method, url="url", out_model=OutModel, **kwargs)
+
+        if actual_status not in expected_statuses:
+            if actual_status >= 400:
+                if with_detail:
+                    assert result.error.detail == "a detail"
+                else:
+                    assert exc.match("BOOP")
+            else:
+                assert exc.match("Can't process response:")
+        else:
+            assert result.out_field == 7
+
+    def test_list_sessions(self):
+        dclient = DuffyClient()
+        with mock.patch.object(dclient, "_query_method") as query_method:
+            dclient.list_sessions()
+        query_method.assert_called_once_with(
+            _MethodEnum.get, "/sessions", out_model=SessionResultCollection
+        )
+
+    def test_show_session(self):
+        dclient = DuffyClient()
+        with mock.patch.object(dclient, "_query_method") as query_method:
+            dclient.show_session(15)
+        query_method.assert_called_once_with(
+            _MethodEnum.get, "/sessions/15", out_model=SessionResult
+        )
+
+    def test_request_session(self):
+        dclient = DuffyClient()
+        with mock.patch.object(dclient, "_query_method") as query_method:
+            dclient.request_session([{"pool": "pool", "quantity": "31"}])
+        query_method.assert_called_once_with(
+            _MethodEnum.post,
+            "/sessions",
+            in_dict={"nodes_specs": [{"pool": "pool", "quantity": "31"}]},
+            in_model=SessionCreateModel,
+            out_model=SessionResult,
+            expected_status=HTTPStatus.CREATED,
+        )
+
+    def test_retire_session(self):
+        dclient = DuffyClient()
+        with mock.patch.object(dclient, "_query_method") as query_method:
+            dclient.retire_session(53)
+        query_method.assert_called_once_with(
+            _MethodEnum.put,
+            "/sessions/53",
+            in_dict={"active": False},
+            in_model=SessionUpdateModel,
+            out_model=SessionResult,
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -225,7 +225,7 @@ def test_migration_upgrade_downgrade(alembic_migration, subcommand, runner):
 @pytest.mark.duffy_config(example_config=True)
 @mock.patch("duffy.shell.embed_shell")
 @mock.patch("duffy.database.init_model")
-def test_shell(
+def test_dev_shell(
     init_model, embed_shell, runner, duffy_config_files, config_error, shell_type, tmp_path
 ):
     # Ensure it's only one config file.
@@ -240,7 +240,7 @@ def test_shell(
         with config_file.open("w") as fp:
             yaml.dump(modified_config, fp)
 
-    args = [f"--config={config_file.absolute()}", "shell"]
+    args = [f"--config={config_file.absolute()}", "dev-shell"]
 
     if shell_type:
         args.append(f"--shell-type={shell_type}")
@@ -252,7 +252,7 @@ def test_shell(
     # the --shell-type option.
 
     # First, dig out the relevant click.Option object, ...
-    shell_type_option = [o for o in cli.commands["shell"].params if o.name == "shell_type"][0]
+    shell_type_option = [o for o in cli.commands["dev-shell"].params if o.name == "shell_type"][0]
     # ... then temporarily mock its type with a click.Choice of a static list.
     with mock.patch.object(shell_type_option, "type", new=click.Choice(["python", "ipython"])):
         result = runner.invoke(cli, args)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,6 +55,9 @@ class TestIntOrNoneType:
 
         assert exc.match("'hello' is not a valid integer")
 
+    def test_convert_valid(self):
+        assert duffy.cli.INT_OR_NONE.convert("5", None, None) == 5
+
 
 class TestIntervalOrNoneType:
     def test_convert_verbatim(self):
@@ -69,6 +72,9 @@ class TestIntervalOrNoneType:
             duffy.cli.INTERVAL_OR_NONE.convert("hello", "<param>", None)
 
         assert exc.match("invalid timedelta format")
+
+    def test_convert_valid(self):
+        assert duffy.cli.INTERVAL_OR_NONE.convert("5h", None, None) == timedelta(hours=5)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
```
commit 8c7dde09dd888d1d426d6808652555f238173d4c
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon May 30 15:57:56 2022 +0200

    Rename `shell` command to `dev-shell`
    
    This should make it less confusing what the command is about.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit fd31412950a2068f4f35298da1e8d5dd69508649
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon May 30 16:06:06 2022 +0200

    Tighten down legacy API configuration schema
    
    Mark `legacy.dest` as an HTTP URL.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 18dfd0dd6c56e0cf060d3aeca753f2db80e9c187
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue May 31 17:32:43 2022 +0200

    Add missing unit tests for custom click types
    
    The "valid value" use cases were only tested as a side effect of
    invoking the CLI before.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 2b5a9743d9e369a7892c7ea9cd3e2fb0015935f4
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon May 30 16:07:36 2022 +0200

    Add `duffy client` subcommands
    
    These let tenants request, retire, show and list sessions.
    
    Fixes: #420
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 75269dc69ec2b791b847d7e5a23895407e01a32d
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Jun 1 14:33:09 2022 +0200

    Make task worker optional for `duffy client`
    
    Before, missing dependencies would cause the CLI not to work at all.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit d3194fcb24bac73b3959236aee932a3c93ceea32
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Jun 2 12:46:40 2022 +0200

    Straighten out package extras
    
    Previously, the app serving the API was the base line for dependencies,
    but that pulls in a lot of unneeded packages if you only want to use the
    client. This defines `app` as its own extra and adds code to deal better
    with cases where a command is used that needs another extra of the
    `duffy` package to be installed.
    
    Additionally, add Jinja2 as a package for the legacy extra, which was
    missing before.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```