### PR TITLE
Fix dependencies (primarily for `duffy client ...` but also elsewhere) and distinguish `admin` and `client` commands better

### DIFF
--- a/duffy/api_models/node.py
+++ b/duffy/api_models/node.py
@@ -3,7 +3,10 @@ from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, IPvAnyAddress
 
-from ..database.types import NodeState
+try:
+    from ..database.types import NodeState
+except ImportError:  # pragma: no cover
+    NodeState = str
 from .common import APIResult, CreatableMixin, RetirableMixin
 
 # abstract node

--- a/duffy/api_models/session.py
+++ b/duffy/api_models/session.py
@@ -4,7 +4,10 @@ from typing import Any, Dict, List, Optional, Union
 
 from pydantic import BaseModel, conint
 
-from ..database.types import NodeState
+try:
+    from ..database.types import NodeState
+except ImportError:  # pragma: no cover
+    NodeState = str
 from ..misc import APITimeDelta
 from .common import APIResult, CreatableMixin, RetirableMixin
 from .node import NodeBase

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -409,16 +409,16 @@ class FakeAPITenant:
     is_admin = True
 
 
-@cli.group()
-def tenant():
+@cli.group("admin")
+def admin_group():
     """Administrate Duffy tenants."""
     pass
 
 
-@tenant.command("list")
+@admin_group.command("list-tenants")
 @click.option("--quiet/--no-quiet", default=False, help="Show only tenant information.")
 @click.option("--active/--all", default=True, help="Whether to list retired tenants.")
-def tenant_list(quiet, active):
+def admin_list_tenants(quiet, active):
     """List tenants."""
     admin_ctx = admin.AdminContext.create_for_cli()
     result = admin_ctx.list_tenants()
@@ -435,9 +435,9 @@ def tenant_list(quiet, active):
             click.echo(f"{prefix}{tenant.name}")
 
 
-@tenant.command("show")
+@admin_group.command("show-tenant")
 @click.argument("name")
-def tenant_show(name: str):
+def admin_show_tenant(name: str):
     """Show a tenant."""
     admin_ctx = admin.AdminContext.create_for_cli()
     result = admin_ctx.show_tenant(name)
@@ -457,7 +457,7 @@ def tenant_show(name: str):
         )
 
 
-@tenant.command("create")
+@admin_group.command("create-tenant")
 @click.option(
     "--is-admin/--no-is-admin",
     default=False,
@@ -483,7 +483,7 @@ def tenant_show(name: str):
 )
 @click.argument("name")
 @click.argument("ssh_key")
-def tenant_create(
+def admin_create_tenant(
     name: str,
     ssh_key: str,
     is_admin: bool,
@@ -508,10 +508,10 @@ def tenant_create(
         click.echo(f"OK: {name}: {result['tenant'].api_key}")
 
 
-@tenant.command("retire")
+@admin_group.command("retire-tenant")
 @click.option("--retire/--unretire", default=True, help="Whether to retire or unretire a tenant.")
 @click.argument("name")
-def tenant_retire(name: str, retire: bool = True):
+def admin_retire_tenant(name: str, retire: bool = True):
     """Retire or unretire a tenant."""
     admin_ctx = admin.AdminContext.create_for_cli()
     result = admin_ctx.retire_unretire_tenant(name, retire=retire)
@@ -522,7 +522,7 @@ def tenant_retire(name: str, retire: bool = True):
         click.echo(f"OK: {name}: active={result['tenant'].active}")
 
 
-@tenant.command("update")
+@admin_group.command("update-tenant")
 @click.option("--ssh-key", help="New SSH key for the tenant.")
 @click.option(
     "--api-key", help="Either a new API key (UUID) for the tenant or 'reset' to set automatically."
@@ -546,7 +546,7 @@ def tenant_retire(name: str, retire: bool = True):
     help="The maximum session lifetime for this tenant.",
 )
 @click.argument("name")
-def tenant_update(
+def admin_update_tenant(
     name: str,
     node_quota: Optional[Union[int, SentinelType]],
     session_lifetime: Optional[Union[timedelta, SentinelType]],

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,7 +13,7 @@ pycares = ">=4.0.0"
 name = "aiosqlite"
 version = "0.17.0"
 description = "asyncio bridge to the standard sqlite3 module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -42,7 +42,7 @@ name = "amqp"
 version = "5.1.1"
 description = "Low-level AMQP client for Python (fork of amqplib)."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
@@ -219,7 +219,7 @@ name = "billiard"
 version = "3.6.4.0"
 description = "Python multiprocessing fork with improvements and bugfixes"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -279,7 +279,7 @@ name = "celery"
 version = "5.2.7"
 description = "Distributed Task Queue."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -383,7 +383,7 @@ name = "click-didyoumean"
 version = "0.3.0"
 description = "Enables git-like *did-you-mean* feature in click"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6.2,<4.0.0"
 
 [package.dependencies]
@@ -394,7 +394,7 @@ name = "click-plugins"
 version = "1.1.1"
 description = "An extension module for click to enable registering CLI commands via setuptools entry-points."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -408,7 +408,7 @@ name = "click-repl"
 version = "0.2.0"
 description = "REPL plugin for Click"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -439,14 +439,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.4"
+version = "6.4.1"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-tomli = {version = "*", optional = true, markers = "python_version < \"3.11\" and extra == \"toml\""}
+tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.11.0a6\" and extra == \"toml\""}
 
 [package.extras]
 toml = ["tomli"]
@@ -899,7 +899,7 @@ name = "kombu"
 version = "5.2.4"
 description = "Messaging library for Python."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.dependencies]
@@ -1186,7 +1186,7 @@ name = "prompt-toolkit"
 version = "3.0.29"
 description = "Library for building powerful interactive command lines in Python"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6.2"
 
 [package.dependencies]
@@ -1425,7 +1425,7 @@ name = "pytz"
 version = "2022.1"
 description = "World timezone definitions, modern and historical"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -1765,7 +1765,7 @@ name = "vine"
 version = "5.0.0"
 description = "Promises, promises, promises."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.6"
 
 [[package]]
@@ -1791,7 +1791,7 @@ name = "wcwidth"
 version = "0.2.5"
 description = "Measures the displayed width of unicode strings in a terminal"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [[package]]
@@ -1834,18 +1834,21 @@ docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "ipython", "psycopg2", "asyncpg", "httpx"]
-app = ["SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
+admin = ["SQLAlchemy", "bcrypt", "fastapi"]
+all = ["SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery", "ipython", "psycopg2", "asyncpg", "httpx"]
+app = ["SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn", "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 client = ["httpx"]
-devshell = ["ipython"]
+database = ["SQLAlchemy", "alembic", "bcrypt"]
+dev-shell = ["ipython", "SQLAlchemy", "alembic", "bcrypt"]
 legacy = ["httpx", "Jinja2"]
 postgresql = ["psycopg2", "asyncpg"]
-tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
+sqlite = ["aiosqlite"]
+tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6a63f0ac4b81bb65905e145b7537e245cfcbc3be3623a13e170584b18fa3b5c1"
+content-hash = "20028ff44f0b59fee6779068e985f3f90d8665f0acb110232cdbe7f862e3d38c"
 
 [metadata.files]
 aiodns = [
@@ -2081,47 +2084,47 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:50ed480b798febce113709846b11f5d5ed1e529c88d8ae92f707806c50297abf"},
-    {file = "coverage-6.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:26f8f92699756cb7af2b30720de0c5bb8d028e923a95b6d0c891088025a1ac8f"},
-    {file = "coverage-6.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:60c2147921da7f4d2d04f570e1838db32b95c5509d248f3fe6417e91437eaf41"},
-    {file = "coverage-6.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:750e13834b597eeb8ae6e72aa58d1d831b96beec5ad1d04479ae3772373a8088"},
-    {file = "coverage-6.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af5b9ee0fc146e907aa0f5fb858c3b3da9199d78b7bb2c9973d95550bd40f701"},
-    {file = "coverage-6.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:a022394996419142b33a0cf7274cb444c01d2bb123727c4bb0b9acabcb515dea"},
-    {file = "coverage-6.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:5a78cf2c43b13aa6b56003707c5203f28585944c277c1f3f109c7b041b16bd39"},
-    {file = "coverage-6.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:9229d074e097f21dfe0643d9d0140ee7433814b3f0fc3706b4abffd1e3038632"},
-    {file = "coverage-6.4-cp310-cp310-win32.whl", hash = "sha256:fb45fe08e1abc64eb836d187b20a59172053999823f7f6ef4f18a819c44ba16f"},
-    {file = "coverage-6.4-cp310-cp310-win_amd64.whl", hash = "sha256:3cfd07c5889ddb96a401449109a8b97a165be9d67077df6802f59708bfb07720"},
-    {file = "coverage-6.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:03014a74023abaf5a591eeeaf1ac66a73d54eba178ff4cb1fa0c0a44aae70383"},
-    {file = "coverage-6.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c82f2cd69c71698152e943f4a5a6b83a3ab1db73b88f6e769fabc86074c3b08"},
-    {file = "coverage-6.4-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b546cf2b1974ddc2cb222a109b37c6ed1778b9be7e6b0c0bc0cf0438d9e45a6"},
-    {file = "coverage-6.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cc173f1ce9ffb16b299f51c9ce53f66a62f4d975abe5640e976904066f3c835d"},
-    {file = "coverage-6.4-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:c53ad261dfc8695062fc8811ac7c162bd6096a05a19f26097f411bdf5747aee7"},
-    {file = "coverage-6.4-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:eef5292b60b6de753d6e7f2d128d5841c7915fb1e3321c3a1fe6acfe76c38052"},
-    {file = "coverage-6.4-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:543e172ce4c0de533fa892034cce260467b213c0ea8e39da2f65f9a477425211"},
-    {file = "coverage-6.4-cp37-cp37m-win32.whl", hash = "sha256:00c8544510f3c98476bbd58201ac2b150ffbcce46a8c3e4fb89ebf01998f806a"},
-    {file = "coverage-6.4-cp37-cp37m-win_amd64.whl", hash = "sha256:b84ab65444dcc68d761e95d4d70f3cfd347ceca5a029f2ffec37d4f124f61311"},
-    {file = "coverage-6.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d548edacbf16a8276af13063a2b0669d58bbcfca7c55a255f84aac2870786a61"},
-    {file = "coverage-6.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:033ebec282793bd9eb988d0271c211e58442c31077976c19c442e24d827d356f"},
-    {file = "coverage-6.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742fb8b43835078dd7496c3c25a1ec8d15351df49fb0037bffb4754291ef30ce"},
-    {file = "coverage-6.4-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d55fae115ef9f67934e9f1103c9ba826b4c690e4c5bcf94482b8b2398311bf9c"},
-    {file = "coverage-6.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5cd698341626f3c77784858427bad0cdd54a713115b423d22ac83a28303d1d95"},
-    {file = "coverage-6.4-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:62d382f7d77eeeaff14b30516b17bcbe80f645f5cf02bb755baac376591c653c"},
-    {file = "coverage-6.4-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:016d7f5cf1c8c84f533a3c1f8f36126fbe00b2ec0ccca47cc5731c3723d327c6"},
-    {file = "coverage-6.4-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:69432946f154c6add0e9ede03cc43b96e2ef2733110a77444823c053b1ff5166"},
-    {file = "coverage-6.4-cp38-cp38-win32.whl", hash = "sha256:83bd142cdec5e4a5c4ca1d4ff6fa807d28460f9db919f9f6a31babaaa8b88426"},
-    {file = "coverage-6.4-cp38-cp38-win_amd64.whl", hash = "sha256:4002f9e8c1f286e986fe96ec58742b93484195defc01d5cc7809b8f7acb5ece3"},
-    {file = "coverage-6.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e4f52c272fdc82e7c65ff3f17a7179bc5f710ebc8ce8a5cadac81215e8326740"},
-    {file = "coverage-6.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b5578efe4038be02d76c344007b13119b2b20acd009a88dde8adec2de4f630b5"},
-    {file = "coverage-6.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d8099ea680201c2221f8468c372198ceba9338a5fec0e940111962b03b3f716a"},
-    {file = "coverage-6.4-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a00441f5ea4504f5abbc047589d09e0dc33eb447dc45a1a527c8b74bfdd32c65"},
-    {file = "coverage-6.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e76bd16f0e31bc2b07e0fb1379551fcd40daf8cdf7e24f31a29e442878a827c"},
-    {file = "coverage-6.4-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8d2e80dd3438e93b19e1223a9850fa65425e77f2607a364b6fd134fcd52dc9df"},
-    {file = "coverage-6.4-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:341e9c2008c481c5c72d0e0dbf64980a4b2238631a7f9780b0fe2e95755fb018"},
-    {file = "coverage-6.4-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:21e6686a95025927775ac501e74f5940cdf6fe052292f3a3f7349b0abae6d00f"},
-    {file = "coverage-6.4-cp39-cp39-win32.whl", hash = "sha256:968ed5407f9460bd5a591cefd1388cc00a8f5099de9e76234655ae48cfdbe2c3"},
-    {file = "coverage-6.4-cp39-cp39-win_amd64.whl", hash = "sha256:e35217031e4b534b09f9b9a5841b9344a30a6357627761d4218818b865d45055"},
-    {file = "coverage-6.4-pp36.pp37.pp38-none-any.whl", hash = "sha256:e637ae0b7b481905358624ef2e81d7fb0b1af55f5ff99f9ba05442a444b11e45"},
-    {file = "coverage-6.4.tar.gz", hash = "sha256:727dafd7f67a6e1cad808dc884bd9c5a2f6ef1f8f6d2f22b37b96cb0080d4f49"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b"},
+    {file = "coverage-6.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84"},
+    {file = "coverage-6.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749"},
+    {file = "coverage-6.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4"},
+    {file = "coverage-6.4.1-cp310-cp310-win32.whl", hash = "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df"},
+    {file = "coverage-6.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6"},
+    {file = "coverage-6.4.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4"},
+    {file = "coverage-6.4.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3"},
+    {file = "coverage-6.4.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6"},
+    {file = "coverage-6.4.1-cp37-cp37m-win32.whl", hash = "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e"},
+    {file = "coverage-6.4.1-cp37-cp37m-win_amd64.whl", hash = "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"},
+    {file = "coverage-6.4.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9"},
+    {file = "coverage-6.4.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428"},
+    {file = "coverage-6.4.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83"},
+    {file = "coverage-6.4.1-cp38-cp38-win32.whl", hash = "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b"},
+    {file = "coverage-6.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df"},
+    {file = "coverage-6.4.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3"},
+    {file = "coverage-6.4.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72"},
+    {file = "coverage-6.4.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264"},
+    {file = "coverage-6.4.1-cp39-cp39-win32.whl", hash = "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9"},
+    {file = "coverage-6.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397"},
+    {file = "coverage-6.4.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815"},
+    {file = "coverage-6.4.1.tar.gz", hash = "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c"},
 ]
 crashtest = [
     {file = "crashtest-0.3.1-py3-none-any.whl", hash = "sha256:300f4b0825f57688b47b6d70c6a31de33512eb2fa1ac614f780939aa0cf91680"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,23 +36,25 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.8"
+click = "^8.0.3"
 PyYAML = "^6"
 SQLAlchemy = {version = "^1.4.25", extras=["asyncio"], optional = true}
 alembic = {version = "^1.7.5", optional = true}
 bcrypt = {version = "^3.2", optional = true}
-click = "^8.0.3"
 fastapi = {version = ">=0.70", optional = true}
 uvicorn = {version = ">=0.15", optional = true}
 Jinja2 = {version = "^3.0.3", optional = true}
 ansible-runner = {version = "^2.1.1", optional = true}
 asyncpg = {version = "^0.25", optional = true}
-celery = {version = "^5.2.1", extras = ["redis"]}
+celery = {version = "^5.2.1", extras = ["redis"], optional = true}
 httpx = {version = ">=0.18.2", optional = true}
 ipython = {version = ">=7.29", optional = true}
 jmespath = {version = ">=0.10", optional = true}
 pottery = {version = "^3", optional = true}
 psycopg2 = {version = "^2.9.2", optional = true}
 aiodns = {version = "^3.0.0", optional = true}
+pydantic = ">=1.6.2"
+aiosqlite = {version = ">=0.17.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 Jinja2 = "^3.0.3"
@@ -79,7 +81,7 @@ tox = "^3.24.4"
 # keep this in sync with the real extras
 all = [
     "SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn",
-    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery",
+    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery",
     "ipython",
     "psycopg2", "asyncpg",
     "httpx",
@@ -88,14 +90,20 @@ all = [
 # the `serve` command
 app = [
     "SQLAlchemy", "alembic", "bcrypt", "fastapi", "uvicorn",
-    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery",
+    "aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery",
 ]
+# the `admin ...` commands
+admin = ["SQLAlchemy", "bcrypt", "fastapi"]
+# the `setup-db` and `migration` commands
+database = ["SQLAlchemy", "alembic", "bcrypt"]
 # the `dev-shell` command
-devshell = ["ipython"]
-# the `serve`, `worker` and `dev-shell` commands if you use PostgreSQL
+dev-shell = ["ipython", "SQLAlchemy", "alembic", "bcrypt"]
+# the `serve` and `dev-shell` commands, if you use SQLite
+sqlite = ["aiosqlite"]
+# the `serve`, `worker` and `dev-shell` commands, if you use PostgreSQL
 postgresql = ["psycopg2", "asyncpg"]
 # the `worker` command
-tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery"]
+tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 # the `serve-legacy` command
 legacy = ["httpx", "Jinja2"]
 # the `client ...` commands

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -388,7 +388,7 @@ def test_serve_legacy(uvicorn_run, testcase, runner, duffy_config_files, tmp_pat
 @mock.patch.object(duffy.cli.admin.AdminContext, "create_for_cli")
 class TestAdminCLI:
     @pytest.mark.parametrize("testcase", ("success", "failure"))
-    def test_tenant_list(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
+    def test_list_tenants(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
         caplog.set_level(logging.DEBUG)
         (config_file,) = duffy_config_files
 
@@ -406,7 +406,7 @@ class TestAdminCLI:
         else:
             admin_ctx.list_tenants.return_value = {"error": {"detail": "BOOM"}}
 
-        parameters = (f"--config={config_file.absolute()}", "tenant", "list")
+        parameters = (f"--config={config_file.absolute()}", "admin", "list-tenants")
 
         result = runner.invoke(cli, parameters)
 
@@ -418,7 +418,7 @@ class TestAdminCLI:
             assert result.stdout.strip() == "ERROR: couldn't list tenants\nERROR DETAIL: BOOM"
 
     @pytest.mark.parametrize("testcase", ("success", "failure"))
-    def test_tenant_show(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
+    def test_show_tenant(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
         caplog.set_level(logging.DEBUG)
         (config_file,) = duffy_config_files
 
@@ -432,7 +432,7 @@ class TestAdminCLI:
         else:
             admin_ctx.show_tenant.return_value = {"error": {"detail": "BAR"}}
 
-        parameters = (f"--config={config_file.absolute()}", "tenant", "show", "tenant-name")
+        parameters = (f"--config={config_file.absolute()}", "admin", "show-tenant", "tenant-name")
 
         result = runner.invoke(cli, parameters)
 
@@ -444,7 +444,7 @@ class TestAdminCLI:
             assert result.stdout.strip() == "ERROR: tenant-name\nERROR DETAIL: BAR"
 
     @pytest.mark.parametrize("testcase", ("success", "failure"))
-    def test_tenant_create(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
+    def test_create_tenant(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
         caplog.set_level(logging.DEBUG)
         (config_file,) = duffy_config_files
 
@@ -459,8 +459,8 @@ class TestAdminCLI:
 
         parameters = (
             f"--config={config_file.absolute()}",
-            "tenant",
-            "create",
+            "admin",
+            "create-tenant",
             "tenant-name",
             "# no SSH key",
         )
@@ -475,7 +475,7 @@ class TestAdminCLI:
             assert result.stdout.strip() == "ERROR: tenant-name\nERROR DETAIL: FOO"
 
     @pytest.mark.parametrize("testcase", ("retire", "unretire", "failure"))
-    def test_tenant_retire_unretire(
+    def test_retire_unretire_tenant(
         self, create_for_cli, testcase, runner, duffy_config_files, caplog
     ):
         caplog.set_level(logging.DEBUG)
@@ -495,8 +495,8 @@ class TestAdminCLI:
 
         parameters = (
             f"--config={config_file.absolute()}",
-            "tenant",
-            "retire",
+            "admin",
+            "retire-tenant",
             "tenant-name",
             "--retire" if retire else "--unretire",
         )
@@ -524,7 +524,7 @@ class TestAdminCLI:
             "missing-arguments",
         ),
     )
-    def test_tenant_update(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
+    def test_update_tenant(self, create_for_cli, testcase, runner, duffy_config_files, caplog):
         caplog.set_level(logging.DEBUG)
         (config_file,) = duffy_config_files
 
@@ -564,7 +564,7 @@ class TestAdminCLI:
 
             admin_ctx.update_tenant.return_value = {"tenant": result_tenant}
 
-        parameters = (f"--config={config_file.absolute()}", "tenant", "update", "tenant-name")
+        parameters = (f"--config={config_file.absolute()}", "admin", "update-tenant", "tenant-name")
 
         if testcase != "missing-arguments":
             parameters += ("--ssh-key", new_ssh_key, "--api-key", new_api_key)


### PR DESCRIPTION
```
commit b7373aff28555242ed5f64a6345b57e70aa095f4
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Jun 2 17:24:46 2022 +0200

    Rename `tenant ...` commands
    
    Mark them explicitly as `admin` commands so they're easier distinguished
    from `client` commands. The former work directly on the database, the
    latter through the API.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 958f2edc38d14c603ab4ed5522bb51d02827511f
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Jun 2 17:29:12 2022 +0200

    Clean up the dependency vs. extras mess a little
    
    This makes how imports are handled in duffy.cli a little unwieldy, but
    that's what you get for monolithic implementations. ;)
    
    Ideally, optional extras should use a plugin system implementing entry
    points which they main app can discover, attempt to load and execute,
    which would only offer sub-commands whose dependencies are all
    available. But not today.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```