### PR TITLE
User configuration and related changes

### DIFF
--- a/duffy/configuration/main.py
+++ b/duffy/configuration/main.py
@@ -1,7 +1,7 @@
 from copy import deepcopy
 from itertools import chain
 from pathlib import Path
-from typing import List, Union
+from typing import List, Sequence, Union
 
 import yaml
 
@@ -26,7 +26,7 @@ def _expand_normalize_config_files(config_files: List[Union[Path, str]]) -> List
 
 
 def read_configuration(
-    *config_files: List[Union[Path, str]], clear: bool = True, validate: bool = True
+    *config_files: Sequence[Union[Path, str]], clear: bool = True, validate: bool = True
 ):
     config_files = _expand_normalize_config_files(config_files)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1437,6 +1437,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pyxdg"
+version = "0.27"
+description = "PyXDG contains implementations of freedesktop.org standards in python."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
@@ -1848,7 +1856,7 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "20028ff44f0b59fee6779068e985f3f90d8665f0acb110232cdbe7f862e3d38c"
+content-hash = "f021a5a83375f75a161042e85724ff6eb20eaeca5c6a9c5bfac328324907f714"
 
 [metadata.files]
 aiodns = [
@@ -2738,6 +2746,10 @@ pytz = [
 pywin32-ctypes = [
     {file = "pywin32-ctypes-0.2.0.tar.gz", hash = "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942"},
     {file = "pywin32_ctypes-0.2.0-py2.py3-none-any.whl", hash = "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"},
+]
+pyxdg = [
+    {file = "pyxdg-0.27-py2.py3-none-any.whl", hash = "sha256:2d6701ab7c74bbab8caa6a95e0a0a129b1643cf6c298bf7c569adec06d0709a0"},
+    {file = "pyxdg-0.27.tar.gz", hash = "sha256:80bd93aae5ed82435f20462ea0208fb198d8eec262e831ee06ce9ddb6b91c5a5"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ psycopg2 = {version = "^2.9.2", optional = true}
 aiodns = {version = "^3.0.0", optional = true}
 pydantic = ">=1.6.2"
 aiosqlite = {version = ">=0.17.0", optional = true}
+pyxdg = ">=0.27"
 
 [tool.poetry.dev-dependencies]
 Jinja2 = "^3.0.3"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -370,7 +370,7 @@ def test_serve(uvicorn_run, testcase, runner, duffy_config_files, tmp_path):
     parameters = (f"--config={config_file.absolute()}", "serve")
 
     if "with-options" in testcase:
-        parameters += ("--host=127.0.0.1", "--port=8080", "--loglevel=info")
+        parameters = ("--loglevel=info",) + parameters + ("--host=127.0.0.1", "--port=8080")
 
     with ctxmgr:
         result = runner.invoke(cli, parameters)
@@ -406,11 +406,10 @@ def test_serve_legacy(uvicorn_run, testcase, runner, duffy_config_files, tmp_pat
     parameters = (f"--config={config_file.absolute()}", "serve-legacy")
 
     if "with-options" in testcase:
-        parameters += (
-            "--host=127.0.0.1",
-            "--port=9090",
-            "--dest=http://127.0.0.1:8080",
-            "--loglevel=info",
+        parameters = (
+            ("--loglevel=info",)
+            + parameters
+            + ("--host=127.0.0.1", "--port=9090", "--dest=http://127.0.0.1:8080")
         )
 
     with ctxmgr:


### PR DESCRIPTION
```
commit 463d05a71c9d6942757d447e3eb18832bf230727
Author: Nils Philippsen <nils@redhat.com>
Date:   Fri Jun 3 15:29:14 2022 +0200

    Set loglevel globally
    
    Previously, this was only set in serve() and serve_legacy(), but we need
    it to see debugging output elsewhere.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 4291b7661d209c901a12167d11343bce2d41b442
Author: Nils Philippsen <nils@redhat.com>
Date:   Fri Jun 3 17:09:27 2022 +0200

    Read user-specific configuration if available
    
    This makes using only the client CLI easier for end users. In the
    course, refactor how configuration files are processed in duffy.cli.
    
    Fixes: #432
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```