### PR TITLE
Add and support metaclient.mangle_hostname configuration option

### DIFF
--- a/ansible/roles/duffy/templates/config/30_logging.yaml.j2
+++ b/ansible/roles/duffy/templates/config/30_logging.yaml.j2
@@ -2,81 +2,9 @@
 app:
   logging:
     version: 1
-    disable_existing_loggers: false
-    formatters:
-      default:
-        (): uvicorn.logging.DefaultFormatter
-        fmt: '%(levelprefix)s %(message)s'
-        use_colors: null
-      access:
-        (): uvicorn.logging.AccessFormatter
-        fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    handlers:
-      default:
-        class: logging.StreamHandler
-        formatter: default
-        stream: ext://sys.stderr
-      access:
-        class: logging.StreamHandler
-        formatter: access
-        stream: ext://sys.stdout
-      syslog:
-        class: logging.handlers.SysLogHandler
-        address: /dev/log
-    loggers:
-      duffy:
-        handlers:
-        - default
-        - syslog
-      uvicorn:
-        handlers:
-        - default
-        level: INFO
-      uvicorn.error:
-        level: INFO
-      uvicorn.access:
-        handlers:
-        - access
-        level: INFO
-        propagate: false
+    # Optional Python standard logging section ...
 
 metaclient:
   logging:
     version: 1
-    disable_existing_loggers: false
-    formatters:
-      default:
-        (): uvicorn.logging.DefaultFormatter
-        fmt: '%(levelprefix)s %(message)s'
-        use_colors: null
-      access:
-        (): uvicorn.logging.AccessFormatter
-        fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    handlers:
-      default:
-        class: logging.StreamHandler
-        formatter: default
-        stream: ext://sys.stderr
-      access:
-        class: logging.StreamHandler
-        formatter: access
-        stream: ext://sys.stdout
-      syslog:
-        class: logging.handlers.SysLogHandler
-        address: /dev/log
-    loggers:
-      duffy:
-        handlers:
-        - default
-        - syslog
-      uvicorn:
-        handlers:
-        - default
-        level: INFO
-      uvicorn.error:
-        level: INFO
-      uvicorn.access:
-        handlers:
-        - access
-        level: INFO
-        propagate: false
+    # Optional Python standard logging section ...

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -348,7 +348,7 @@ def serve(obj, reload, host, port):
     print(f" * Serving API docs on http://{host}:{port}/docs")
 
     uvicorn_log_config = copy.deepcopy(config_app.get("logging", uvicorn.config.LOGGING_CONFIG))
-    if uvicorn_log_config.get("loggers", {}).get("duffy"):
+    if "duffy" in uvicorn_log_config.get("loggers", {}):
         uvicorn_log_config["loggers"]["duffy"]["level"] = numeric_loglevel
 
     # Start the show
@@ -423,7 +423,7 @@ def serve_legacy(obj, reload, host, port, dest):
     uvicorn_log_config = copy.deepcopy(
         config_metaclient.get("logging", uvicorn.config.LOGGING_CONFIG)
     )
-    if uvicorn_log_config.get("loggers", {}).get("duffy"):
+    if "duffy" in uvicorn_log_config.get("loggers", {}):
         uvicorn_log_config["loggers"]["duffy"]["level"] = numeric_loglevel
 
     # Start the show

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -148,6 +148,7 @@ class LegacyModel(ConfigBaseModel):
     logging: Optional[LoggingModel]
     usermap: Dict[str, str]
     poolmap: List[LegacyPoolMapModel]
+    mangle_hostname: Optional[str]
 
 
 class ConfigModel(ConfigBaseModel):

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -65,6 +65,9 @@ metaclient:
     pool: "virtual-centos{{ ver | replace('-', '') }}-{{ arch }}-{{ flavor | default('medium') }}"
   - arch: "x86_64"
     pool: "physical-centos{{ ver | replace('-', '') }}-{{ arch }}"
+  # Optional Jinja2 template to mangle hostnames. The `hostname` variable will be set in the
+  # template when it’s rendered, e.g.:
+  # mangle_hostname: "{{ hostname | replace('.ci.centos.org', '') }}"
   logging:
     version: 1
     disable_existing_loggers: false

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -9,45 +9,12 @@ app:
   loglevel: warning
   host: 0.0.0.0
   port: 8080
+
+  # The `logging` section is optional and follows the standard logging configuration dictionary
+  # schema, see https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
   logging:
     version: 1
     disable_existing_loggers: false
-    formatters:
-      default:
-        (): uvicorn.logging.DefaultFormatter
-        fmt: '%(levelprefix)s %(message)s'
-        use_colors: null
-      access:
-        (): uvicorn.logging.AccessFormatter
-        fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    handlers:
-      default:
-        class: logging.StreamHandler
-        formatter: default
-        stream: ext://sys.stderr
-      access:
-        class: logging.StreamHandler
-        formatter: access
-        stream: ext://sys.stdout
-      syslog:
-        class: logging.handlers.SysLogHandler
-        address: /dev/log
-    loggers:
-      duffy:
-        handlers:
-        - default
-        - syslog
-      uvicorn:
-        handlers:
-        - default
-        level: INFO
-      uvicorn.error:
-        level: INFO
-      uvicorn.access:
-        handlers:
-        - access
-        level: INFO
-        propagate: false
 
 metaclient:
   loglevel: warning
@@ -68,45 +35,12 @@ metaclient:
   # Optional Jinja2 template to mangle hostnames. The `hostname` variable will be set in the
   # template when it’s rendered, e.g.:
   # mangle_hostname: "{{ hostname | replace('.ci.centos.org', '') }}"
+
+  # The `logging` section is optional and follows the standard logging configuration dictionary
+  # schema, see https://docs.python.org/3/library/logging.config.html#logging-config-dictschema
   logging:
     version: 1
     disable_existing_loggers: false
-    formatters:
-      default:
-        (): uvicorn.logging.DefaultFormatter
-        fmt: '%(levelprefix)s %(message)s'
-        use_colors: null
-      access:
-        (): uvicorn.logging.AccessFormatter
-        fmt: '%(levelprefix)s %(client_addr)s - "%(request_line)s" %(status_code)s'
-    handlers:
-      default:
-        class: logging.StreamHandler
-        formatter: default
-        stream: ext://sys.stderr
-      access:
-        class: logging.StreamHandler
-        formatter: access
-        stream: ext://sys.stdout
-      syslog:
-        class: logging.handlers.SysLogHandler
-        address: /dev/log
-    loggers:
-      duffy:
-        handlers:
-        - default
-        - syslog
-      uvicorn:
-        handlers:
-        - default
-        level: INFO
-      uvicorn.error:
-        level: INFO
-      uvicorn.access:
-        handlers:
-        - access
-        level: INFO
-        propagate: false
 
 tasks:
   celery:

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -154,6 +154,20 @@ class TestMain:
 
         assert pool == expected
 
+    @pytest.mark.parametrize("testcase", ("is_set", "is_unset", "is_none"))
+    @pytest.mark.parametrize("hostname", ("foo", "", None))
+    def test_mangle_hostname(self, hostname, testcase):
+        _hostname = hostname or ""
+
+        if testcase == "is_set":
+            config["metaclient"]["mangle_hostname"] = "{{ hostname }}-bar"
+            expected = f"{_hostname}-bar"
+        elif testcase in ("is_unset", "is_none"):
+            config["metaclient"].pop("mangle_hostname", None)
+            expected = hostname
+
+        assert main.mangle_hostname(hostname) == expected
+
     @mock.patch("duffy.legacy.main.httpx.AsyncClient")
     async def test_request_nodes_physical_auth(self, AsyncClient, client):
         apiv1_client, apiv1_response = self._setup_async_client(AsyncClient, "post")


### PR DESCRIPTION
This lets operators configure Jinja2 templates with which to
post-process hostnames before returning them to users of the legacy API.
The reason is that legacy Duffy only returned unqualified hostnames to
which some users simply appended ".ci.centos.org".

Fixes: #463

Signed-off-by: Nils Philippsen <nils@redhat.com>