### PR TITLE
Return the SSID as a string in the legacy API

### DIFF
--- a/duffy/legacy/main.py
+++ b/duffy/legacy/main.py
@@ -197,7 +197,7 @@ async def get_nodes(cred: Optional[Credentials] = Depends(req_credentials_option
                     0,  # sch.data['used_count']
                     session_node.get("state"),  # sch.data['state']
                     # Yes, 'comment' contains the session id. Don't ask.
-                    session.get("id"),  # sch.data['comment']
+                    str(session.get("id")),  # sch.data['comment']
                     None,  # sch.data['distro']
                     None,  # sch.data['rel']
                     None,  # sch.data['ver']

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -465,7 +465,9 @@ class TestMain:
                 for node in result
             )
             if long_form:
-                assert all(self.noderesult_to_dict(node, True)["comment"] == 15 for node in result)
+                assert all(
+                    self.noderesult_to_dict(node, True)["comment"] == "15" for node in result
+                )
         elif "incorrect-auth" in testcase:
             assert response.status_code == HTTP_403_FORBIDDEN
         elif "incorrect-query" in testcase or "apiv1-failure" in testcase:


### PR DESCRIPTION
python-cicoclient expects it to be a string. Sending it as an integer causes comparisons to fail because 505 != '505'.

See https://github.com/CentOS/python-cicoclient/pull/36 for details.

I did not consider too many things since I'm unfamiliar with the codebase. For example, I don't know if this can return None (`str(None)` fails). Given how cico works I'd expect it to always have SSIDs, but review carefully.