### PR TITLE
Transaction isolation etc.

### DIFF
--- a/duffy/app/controllers/session.py
+++ b/duffy/app/controllers/session.py
@@ -149,6 +149,7 @@ async def create_session(
             select(Node)
             .filter_by(active=True, state=NodeState.ready, **nodes_spec_dict)
             .limit(quantity)
+            .with_for_update()
         )
 
         nodes_to_reserve = (await db_async_session.execute(query)).scalars().all()

--- a/duffy/database/__init__.py
+++ b/duffy/database/__init__.py
@@ -70,6 +70,7 @@ def get_sync_engine():
             _key_failed_to_config_key.get(key_not_found, key_not_found)
         ) from exc
     sync_config.pop("async_url", None)
+    sync_config["isolation_level"] = "SERIALIZABLE"
     return create_engine(**sync_config)
 
 
@@ -83,4 +84,5 @@ def get_async_engine():
             _key_failed_to_config_key.get(key_not_found, key_not_found)
         ) from exc
     async_config.pop("sync_url", None)
+    async_config["isolation_level"] = "SERIALIZABLE"
     return create_async_engine(**async_config)

--- a/tests/database/test_package.py
+++ b/tests/database/test_package.py
@@ -65,7 +65,10 @@ def test_get_sync_engine(create_engine, testcase):
         create_engine.assert_not_called()
     else:
         database.get_sync_engine()
-        create_engine.assert_called_once_with(url=TEST_CONFIG["database"]["sqlalchemy"]["sync_url"])
+        create_engine.assert_called_once_with(
+            url=TEST_CONFIG["database"]["sqlalchemy"]["sync_url"],
+            isolation_level="SERIALIZABLE",
+        )
 
 
 @pytest.mark.duffy_config(TEST_CONFIG)
@@ -80,5 +83,6 @@ def test_get_async_engine(create_async_engine, testcase):
     else:
         database.get_async_engine()
         create_async_engine.assert_called_once_with(
-            url=TEST_CONFIG["database"]["sqlalchemy"]["async_url"]
+            url=TEST_CONFIG["database"]["sqlalchemy"]["async_url"],
+            isolation_level="SERIALIZABLE",
         )


### PR DESCRIPTION
```
commit 5508eeb4cd61b55b275a699d98f69e971d473aa0
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Aug 3 16:19:04 2022 +0200

    Configure transaction isolation_level properly
    
    I assumed this to be SERIALIZABLE by default, that assumption was wrong.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 89051f774d8fe224e77c4a10e8ab26351248a805
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Aug 3 16:20:29 2022 +0200

    Attempt to fail less on concurrent node allocation
    
    This instructs the database that the selected node candidates could be
    updated, in effect locking their rows until the transaction is
    committed. Concurrently running transactions that attempt to select
    overlapping nodes will be paused until then.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```