### PR TITLE
Allow overriding SQLAlchemy engine parameters

### DIFF
--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -53,7 +53,9 @@ class TasksModel(ConfigBaseModel):
     periodic: Optional[Dict[str, PeriodicTaskModel]]
 
 
-class SQLAlchemyModel(ConfigBaseModel):
+class SQLAlchemyModel(BaseModel):
+    # This is intentionally not a subclass of ConfigBaseModel, it is passed on to SQLAlchemy's
+    # create_engine()/create_async_engine(), i.e. can contain arbitrarily named fields.
     sync_url: stricturl(tld_required=False, host_required=False)
     async_url: stricturl(tld_required=False, host_required=False)
 

--- a/duffy/database/__init__.py
+++ b/duffy/database/__init__.py
@@ -70,7 +70,7 @@ def get_sync_engine():
             _key_failed_to_config_key.get(key_not_found, key_not_found)
         ) from exc
     sync_config.pop("async_url", None)
-    sync_config["isolation_level"] = "SERIALIZABLE"
+    sync_config.setdefault("isolation_level", "SERIALIZABLE")
     return create_engine(**sync_config)
 
 
@@ -84,5 +84,5 @@ def get_async_engine():
             _key_failed_to_config_key.get(key_not_found, key_not_found)
         ) from exc
     async_config.pop("sync_url", None)
-    async_config["isolation_level"] = "SERIALIZABLE"
+    async_config.setdefault("isolation_level", "SERIALIZABLE")
     return create_async_engine(**async_config)


### PR DESCRIPTION
This allows, among other things, mucking around with the transaction
isolation level as a workaround.

Signed-off-by: Nils Philippsen <nils@redhat.com>