### PR TITLE
Retry creating session on DB serialization errors, cleanup temporary directories of ansible-runner and more

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,37 +1,46 @@
 name: CI
 on: [push, pull_request, workflow_dispatch]
 jobs:
-  ci:
+  ci-basic:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-latest
+    container: fedorapython/fedora-python-tox:latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install base Python dependencies
+        run: |
+          python3 -m pip install --upgrade tox
+
+      - name: Execute tox
+        run: |
+          tox -e black,flake8,isort
+
+  ci-unittests:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
-        python-version: ['3.8', '3.9', '3.10']
-    runs-on: ${{ matrix.os }}
+        tox-env: ["py38", "py39", "py310"]
+    runs-on: ubuntu-latest
+    container: fedorapython/fedora-python-tox:latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: setup venv
+      - name: Install RPM dependencies
         run: |
-             python -m pip install --upgrade virtualenv
-             virtualenv venv
-             source venv/bin/activate
-             which python
+          dnf install -y libpq-devel
 
-      - name: Install base dependencies
+      - name: Install base Python dependencies
         run: |
-             source venv/bin/activate
-             python -m pip install --upgrade poetry
-             python -m pip install --upgrade pytest
-             python -m pip install --upgrade tox
+          python3 -m pip install --upgrade poetry
+          python3 -m pip install --upgrade tox
 
-
-      - name: execute tox
+      - name: Set up testrunner user
         run: |
-             source venv/bin/activate
-             tox
+          useradd testrunner
+          chown -R testrunner: .
+
+      - name: Execute tox
+        run: |
+          su testrunner -c 'tox -e ${{ matrix.tox-env }}'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install RPM dependencies
         run: |
-          dnf install -y libpq-devel
+          dnf install -y libpq-devel postgresql-server
 
       - name: Install base Python dependencies
         run: |

--- a/duffy/app/util.py
+++ b/duffy/app/util.py
@@ -1,0 +1,43 @@
+import logging
+from typing import Tuple, Union
+
+try:
+    import asyncpg
+except ImportError:  # pragma: no cover
+    asyncpg = None
+from sqlalchemy.exc import DBAPIError
+
+from ..configuration import config_get
+from ..util import RetryContext
+
+log = logging.getLogger(__name__)
+
+
+class ConfigRetryContext(RetryContext):
+    def __init__(self, *, exceptions: Union[Exception, Tuple[Exception]] = None, **kwargs):
+        for key in (
+            "no-attempts",
+            "delay-min",
+            "delay-max",
+            "delay-backoff-factor",
+            "delay-add-fuzz",
+        ):
+            key_ = key.replace("-", "_")
+            if key_ not in kwargs:
+                kwargs[key_] = config_get(f"app.retries.{key}", f"defaults.retries.{key}")
+        super().__init__(exceptions=exceptions, **kwargs)
+
+
+class SerializationErrorRetryContext(ConfigRetryContext):
+    exceptions = DBAPIError
+
+    def exception_matches(self, exc):
+        log.debug("[%r] Matching %r...", self, exc)
+        if not (super().exception_matches(exc) and asyncpg):
+            log.debug("[%r] Smoke tests failed", self)
+            return False
+
+        result = getattr(exc.orig, "pgcode", None) == asyncpg.SerializationError.sqlstate
+        log.debug("[%r] Match result: %r", self, result)
+
+        return result

--- a/duffy/configuration/__init__.py
+++ b/duffy/configuration/__init__.py
@@ -1,1 +1,1 @@
-from .main import config, read_configuration  # noqa: F401
+from .main import config, config_get, read_configuration  # noqa: F401

--- a/duffy/configuration/main.py
+++ b/duffy/configuration/main.py
@@ -1,7 +1,8 @@
 from copy import deepcopy
+from functools import lru_cache
 from itertools import chain
 from pathlib import Path
-from typing import List, Sequence, Union
+from typing import Any, List, Sequence, Union
 
 import yaml
 
@@ -48,3 +49,20 @@ def read_configuration(
 
     config.clear()
     config.update(new_config)
+
+
+@lru_cache
+def config_get(*keys, default: Any = None):
+    """Retrieve a configuration value from multiple alternative places."""
+    for key in keys:
+        item = config
+        elems = key.split(".")
+        try:
+            for elem in elems:
+                item = item[elem]
+        except KeyError:
+            continue
+        else:
+            return item
+
+    return default

--- a/duffy/configuration/main.py
+++ b/duffy/configuration/main.py
@@ -38,6 +38,8 @@ def read_configuration(
     for config_file in config_files:
         with config_file.open("r") as fp:
             for config_doc in yaml.safe_load_all(fp):
+                if not config_doc:
+                    continue
                 new_config = merge_dicts(new_config, config_doc)
 
     if validate:

--- a/duffy/configuration/validation.py
+++ b/duffy/configuration/validation.py
@@ -4,7 +4,17 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Union
 from uuid import UUID
 
-from pydantic import AnyHttpUrl, AnyUrl, BaseModel, Field, RedisDsn, conint, stricturl, validator
+from pydantic import (
+    AnyHttpUrl,
+    AnyUrl,
+    BaseModel,
+    Field,
+    RedisDsn,
+    confloat,
+    conint,
+    stricturl,
+    validator,
+)
 
 from ..misc import ConfigTimeDelta
 
@@ -64,10 +74,21 @@ class DatabaseModel(ConfigBaseModel):
     sqlalchemy: SQLAlchemyModel
 
 
+class RetriesModel(ConfigBaseModel):
+    no_attempts: Optional[conint(ge=1)] = Field(alias="no-attempts")
+    delay_min: Optional[Union[conint(ge=0), confloat(ge=0)]] = Field(alias="delay-min")
+    delay_max: Optional[Union[conint(ge=0), confloat(ge=0)]] = Field(alias="delay-max")
+    delay_backoff_factor: Optional[Union[conint(ge=1), confloat(ge=1)]] = Field(
+        alias="delay-backoff-factor"
+    )
+    delay_add_fuzz: Optional[Union[conint(ge=0), confloat(ge=0)]] = Field(alias="delay-add-fuzz")
+
+
 class DefaultsModel(ConfigBaseModel):
     session_lifetime: ConfigTimeDelta = Field(alias="session-lifetime")
     session_lifetime_max: ConfigTimeDelta = Field(alias="session-lifetime-max")
     node_quota: conint(gt=0) = Field(alias="node-quota")
+    retries: Optional[RetriesModel]
 
 
 class AnsibleMechanismPlaybookModel(ConfigBaseModel):
@@ -127,6 +148,7 @@ class AppModel(ConfigBaseModel):
     host: Optional[str]
     port: Optional[conint(gt=0, lt=65536)]
     logging: Optional[LoggingModel]
+    retries: Optional[RetriesModel]
 
 
 class LegacyPoolMapModel(ConfigBaseModel):

--- a/duffy/database/util.py
+++ b/duffy/database/util.py
@@ -114,12 +114,12 @@ class utcnow(FunctionElement):
 
 @compiles(utcnow, "postgresql")
 def _postgresql_utcnow(element, compiler, **kwargs):
-    return "(NOW() AT TIME ZONE 'utc')"  # pragma: no cover (unit tests use sqlite)
+    return "(NOW() AT TIME ZONE 'utc')"
 
 
 @compiles(utcnow, "sqlite")
 def _sqlite_utcnow(element, compiler, **kwargs):
-    return "CURRENT_TIMESTAMP"
+    return "CURRENT_TIMESTAMP"  # pragma: no cover (unit tests use postgresql)
 
 
 # Mixins

--- a/duffy/util.py
+++ b/duffy/util.py
@@ -1,4 +1,11 @@
+import asyncio
 import enum
+import logging
+import time
+from random import random
+from typing import AsyncIterator, Iterator, Tuple, Union
+
+log = logging.getLogger(__name__)
 
 
 def camel_case_to_lower_with_underscores(camelcased: str) -> str:
@@ -61,3 +68,160 @@ class SentinelType(enum.Enum):
 
 UNSET = SentinelType.UNSET
 """A sentinel object for unset values."""
+
+
+IntOrFloat = Union[int, float]
+
+
+class RetryContext:
+    """A wrapper for code blocks that should be retried on certain exceptions.
+
+    Use it e.g. like this:
+
+        async with RetryContext(exceptions=RuntimeError) as retry:
+            async for attempt in retry.attempts:
+                # ... set up the things ...
+                try:
+                    # ... do the things ...
+                except retry.exceptions as exc:
+                    # ... undo the things ...
+                    retry.process_exception(exc)
+                finally:
+                    # ... tear down the things ...
+
+    Subclass it e.g. to inspect caught exceptions further in
+    process_exception(), making a decision whether to re-raise or continue
+    with attempts.
+    """
+
+    exceptions: Union[Exception, Tuple[Exception]] = Exception
+    no_attempts: int = 5
+    delay_min: IntOrFloat = 0.1
+    delay_max: IntOrFloat = 1.6
+    delay_backoff_factor: IntOrFloat = 2
+    delay_add_fuzz: IntOrFloat = 0.3
+
+    def __init__(
+        self,
+        *,
+        exceptions: Union[Exception, Tuple[Exception]] = None,
+        no_attempts: int = None,
+        delay_min: IntOrFloat = None,
+        delay_max: IntOrFloat = None,
+        delay_backoff_factor: IntOrFloat = None,
+        delay_add_fuzz: IntOrFloat = None,
+    ):
+        self._is_async = None
+
+        if exceptions is not None:
+            self.exceptions = exceptions
+
+        if no_attempts is not None:
+            self.no_attempts = no_attempts
+
+        if delay_min is not None:
+            self.delay_min = delay_min
+
+        if delay_max is not None:
+            self.delay_max = delay_max
+
+        if delay_backoff_factor is not None:
+            self.delay_backoff_factor = delay_backoff_factor
+
+        if delay_add_fuzz is not None:
+            self.delay_add_fuzz = delay_add_fuzz
+
+    def __enter__(self):
+        self._is_async = False
+        self._exc = None
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    async def __aenter__(self):
+        self._is_async = True
+        self._exc = None
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        pass
+
+    async def _async_attempts(self) -> AsyncIterator[int]:
+        delay = self.delay_min
+
+        for attempt in range(1, self.no_attempts + 1):
+            log.debug("[%r] Attempt %d of %d", self, attempt, self.no_attempts)
+
+            self._exc = None
+
+            yield attempt
+
+            if not self._exc:
+                break
+
+            if attempt < self.no_attempts:
+                log.debug("[%r] Retrying...", self)
+                current_delay = delay + self.delay_add_fuzz * random()
+                await asyncio.sleep(current_delay)
+                delay = max(self.delay_max, delay * self.delay_backoff_factor)
+
+        if self._exc:
+            log.warning(
+                "[%r] Number of attempts (%d) exhausted, re-raising.", self, self.no_attempts
+            )
+            raise self._exc
+
+    def _sync_attempts(self) -> Iterator[int]:
+        # This is the same as _async_attempts, only synchronous
+        delay = self.delay_min
+
+        for attempt in range(1, self.no_attempts + 1):
+            log.debug("[%r] Attempt %d of %d", self, attempt, self.no_attempts)
+
+            self._exc = None
+
+            yield attempt
+
+            if not self._exc:
+                break
+
+            if attempt < self.no_attempts:
+                log.debug("[%r] Retrying...", self)
+                current_delay = delay + self.delay_add_fuzz * random()
+                time.sleep(current_delay)
+                delay = max(self.delay_max, delay * self.delay_backoff_factor)
+
+        if self._exc:
+            log.warning(
+                "[%r] Number of attempts (%d) exhausted, re-raising.", self, self.no_attempts
+            )
+            raise self._exc
+
+    @property
+    def attempts(self) -> Union[AsyncIterator[int], Iterator[int]]:
+        if self._is_async:
+            return self._async_attempts()
+        else:
+            return self._sync_attempts()
+
+    def exception_matches(self, exc: Exception) -> bool:
+        """Check if exception should cause a retry.
+
+        This method can be used to inspect the exception and re-raise it if it
+        doesn't match certain criteria.
+        """
+        return isinstance(exc, self.exceptions)
+
+    def process_exception(self, exc: Exception) -> None:
+        """Further process caught exception.
+
+        This method needs to be called when an exception is caught.
+        """
+        exception_matches = self.exception_matches(exc)
+        log.debug("[%r] Exception %r matches: %r", self, exc, exception_matches)
+        if exception_matches:
+            log.debug("[%r] Setting self._exc: %r", self, exc)
+            self._exc = exc
+        else:
+            raise exc

--- a/etc/duffy-example-config.yaml
+++ b/etc/duffy-example-config.yaml
@@ -16,6 +16,13 @@ app:
     version: 1
     disable_existing_loggers: false
 
+  retries:
+    no-attempts: 5
+    delay-min: 0.1
+    delay-max: 1.6
+    delay-backoff-factor: 2
+    delay-add-fuzz: 0.3
+
 metaclient:
   loglevel: warning
   host: 0.0.0.0
@@ -65,6 +72,12 @@ defaults:
   session-lifetime: "6h"
   session-lifetime-max: "12h"
   node-quota: 10
+  retries:
+    no-attempts: 5
+    delay-min: 0.1
+    delay-max: 1.6
+    delay-backoff-factor: 2
+    delay-add-fuzz: 0.3
 
 nodepools:
   abstract:

--- a/poetry.lock
+++ b/poetry.lock
@@ -189,6 +189,17 @@ optional = true
 python-versions = "*"
 
 [[package]]
+name = "backports.zoneinfo"
+version = "0.2.1"
+description = "Backport of the standard library zoneinfo module"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+tzdata = ["tzdata"]
+
+[[package]]
 name = "bcrypt"
 version = "3.2.2"
 description = "Modern password hashing for your software and your servers"
@@ -259,9 +270,9 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-msgpack = ["msgpack-python (>=0.5,<0.6)"]
-memcached = ["python-memcached (>=1.59,<2.0)"]
 redis = ["redis (>=3.3.6,<4.0.0)"]
+memcached = ["python-memcached (>=1.59,<2.0)"]
+msgpack = ["msgpack-python (>=0.5,<0.6)"]
 
 [[package]]
 name = "celery"
@@ -390,7 +401,7 @@ python-versions = "*"
 click = ">=4.0"
 
 [package.extras]
-dev = ["coveralls", "wheel", "pytest-cov", "pytest (>=3.6)"]
+dev = ["pytest (>=3.6)", "pytest-cov", "wheel", "coveralls"]
 
 [[package]]
 name = "click-repl"
@@ -606,8 +617,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2022.6.21)", "sphinx (>=5.1.1)", "sphinx-autodoc-typehints (>=1.19.1)"]
-testing = ["covdefaults (>=2.2)", "coverage (>=6.4.2)", "pytest (>=7.1.2)", "pytest-cov (>=3)", "pytest-timeout (>=2.1)"]
+testing = ["pytest-timeout (>=2.1)", "pytest-cov (>=3)", "pytest (>=7.1.2)", "coverage (>=6.4.2)", "covdefaults (>=2.2)"]
+docs = ["sphinx-autodoc-typehints (>=1.19.1)", "sphinx (>=5.1.1)", "furo (>=2022.6.21)"]
 
 [[package]]
 name = "flake8"
@@ -673,10 +684,10 @@ six = ">=1.9"
 webencodings = "*"
 
 [package.extras]
-lxml = ["lxml"]
-genshi = ["genshi"]
+all = ["genshi", "chardet (>=2.2)", "lxml"]
 chardet = ["chardet (>=2.2)"]
-all = ["lxml", "chardet (>=2.2)", "genshi"]
+genshi = ["genshi"]
+lxml = ["lxml"]
 
 [[package]]
 name = "httpcore"
@@ -840,8 +851,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-trio = ["async-generator", "trio"]
-test = ["async-timeout", "trio", "testpath", "pytest-asyncio (>=0.17)", "pytest-trio", "pytest"]
+test = ["pytest", "pytest-trio", "pytest-asyncio (>=0.17)", "testpath", "trio", "async-timeout"]
+trio = ["trio", "async-generator"]
 
 [[package]]
 name = "jinja2"
@@ -948,7 +959,7 @@ name = "matplotlib-inline"
 version = "0.1.5"
 description = "Inline Matplotlib backend for Jupyter"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.5"
 
 [package.dependencies]
@@ -961,6 +972,20 @@ description = "McCabe checker, plugin for flake8"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "mirakuru"
+version = "2.4.2"
+description = "Process executor (not only) for tests."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+psutil = {version = ">=4.0.0", markers = "sys_platform != \"cygwin\""}
+
+[package.extras]
+tests = ["pytest", "pytest-cov", "python-daemon"]
 
 [[package]]
 name = "mmh3"
@@ -1120,8 +1145,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poetry"
@@ -1158,6 +1183,17 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
+name = "port-for"
+version = "0.6.2"
+description = "Utility that helps with local TCP ports management. It can find an unused TCP localhost port and remember the association."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+tests = ["pytest-cov", "pytest"]
+
+[[package]]
 name = "pottery"
 version = "3.0.0"
 description = "Redis for Humans."
@@ -1180,6 +1216,37 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 wcwidth = "*"
+
+[[package]]
+name = "psutil"
+version = "5.9.1"
+description = "Cross-platform lib for process and system monitoring in Python."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[package.extras]
+test = ["ipaddress", "mock", "enum34", "pywin32", "wmi"]
+
+[[package]]
+name = "psycopg"
+version = "3.0.16"
+description = "PostgreSQL database adapter for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+"backports.zoneinfo" = {version = ">=0.2.0", markers = "python_version < \"3.9\""}
+tzdata = {version = "*", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+test = ["pytest-randomly (>=3.10)", "pytest-cov (>=3.0)", "pytest-asyncio (>=0.16,<0.17)", "pytest (>=6.2.5)", "pproxy (>=2.7)", "mypy (>=0.920,!=0.930,!=0.931)"]
+pool = ["psycopg-pool"]
+docs = ["sphinx-autodoc-typehints (>=1.12)", "sphinx-autobuild (>=2021.3.14)", "furo (==2022.6.21)", "Sphinx (>=5.0)"]
+dev = ["wheel (>=0.37)", "types-setuptools (>=57.4)", "mypy (>=0.920,!=0.930,!=0.931)", "flake8 (>=4.0)", "dnspython (>=2.1)", "black (>=22.3.0)"]
+c = ["psycopg-c (==3.0.16)"]
+binary = ["psycopg-binary (==3.0.16)"]
 
 [[package]]
 name = "psycopg2"
@@ -1360,7 +1427,7 @@ coverage = {version = ">=5.2.1", extras = ["toml"]}
 pytest = ">=4.6"
 
 [package.extras]
-testing = ["virtualenv", "pytest-xdist", "six", "process-tests", "hunter", "fields"]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
 name = "pytest-flake8"
@@ -1385,6 +1452,22 @@ python-versions = ">=3.6,<4"
 [package.dependencies]
 isort = ">=4.0"
 pytest = ">=5.0"
+
+[[package]]
+name = "pytest-postgresql"
+version = "4.1.1"
+description = "Postgresql fixtures and fixture factories for Pytest."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+mirakuru = ">=2.3.0"
+port-for = "*"
+pytest = ">=6.2.0"
+
+[package.extras]
+tests = ["pytest-cov", "pytest-xdist"]
 
 [[package]]
 name = "python-daemon"
@@ -1676,7 +1759,7 @@ name = "traitlets"
 version = "5.3.0"
 description = ""
 category = "main"
-optional = false
+optional = true
 python-versions = ">=3.7"
 
 [package.extras]
@@ -1722,6 +1805,14 @@ description = "Backported and Experimental Type Hints for Python 3.7+"
 category = "main"
 optional = false
 python-versions = ">=3.7"
+
+[[package]]
+name = "tzdata"
+version = "2022.2"
+description = "Provider of IANA time zone data"
+category = "dev"
+optional = false
+python-versions = ">=2"
 
 [[package]]
 name = "ujson"
@@ -1849,7 +1940,7 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "f021a5a83375f75a161042e85724ff6eb20eaeca5c6a9c5bfac328324907f714"
+content-hash = "bec173edae90512282e48258a7650dca8b9a815f2a8d652ccd4dce192d86446d"
 
 [metadata.files]
 aiodns = [
@@ -1860,10 +1951,7 @@ aiosqlite = [
     {file = "aiosqlite-0.17.0-py3-none-any.whl", hash = "sha256:6c49dc6d3405929b1d08eeccc72306d3677503cc5e5e43771efc1e00232e8231"},
     {file = "aiosqlite-0.17.0.tar.gz", hash = "sha256:f0e6acc24bc4864149267ac82fb46dfb3be4455f99fe21df82609cc6e6baee51"},
 ]
-alembic = [
-    {file = "alembic-1.8.1-py3-none-any.whl", hash = "sha256:0a024d7f2de88d738d7395ff866997314c837be6104e90c5724350313dee4da4"},
-    {file = "alembic-1.8.1.tar.gz", hash = "sha256:cd0b5e45b14b706426b833f06369b9a6d5ee03f826ec3238723ce8caaf6e5ffa"},
-]
+alembic = []
 amqp = [
     {file = "amqp-5.1.1-py3-none-any.whl", hash = "sha256:6f0956d2c23d8fa6e7691934d8c3930eadb44972cbbd1a7ae3a520f735d43359"},
     {file = "amqp-5.1.1.tar.gz", hash = "sha256:2c1b13fecc0893e946c65cbd5f36427861cffa4ea2201d8f6fca22e2a373b5e2"},
@@ -1936,6 +2024,24 @@ attrs = [
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
     {file = "backcall-0.2.0.tar.gz", hash = "sha256:5cbdbf27be5e7cfadb448baf0aa95508f91f2bbc6c6437cd9cd06e2a4c215e1e"},
+]
+"backports.zoneinfo" = [
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:da6013fd84a690242c310d77ddb8441a559e9cb3d3d59ebac9aca1a57b2e18bc"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:89a48c0d158a3cc3f654da4c2de1ceba85263fafb861b98b59040a5086259722"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1c5742112073a563c81f786e77514969acb58649bcdf6cdf0b4ed31a348d4546"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win32.whl", hash = "sha256:e8236383a20872c0cdf5a62b554b27538db7fa1bbec52429d8d106effbaeca08"},
+    {file = "backports.zoneinfo-0.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:8439c030a11780786a2002261569bdf362264f605dfa4d65090b64b05c9f79a7"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04e857b59d9d1ccc39ce2da1021d196e47234873820cbeaad210724b1ee28ac"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:17746bd546106fa389c51dbea67c8b7c8f0d14b5526a579ca6ccf5ed72c526cf"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5c144945a7752ca544b4b78c8c41544cdfaf9786f25fe5ffb10e838e19a27570"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win32.whl", hash = "sha256:e55b384612d93be96506932a786bbcde5a2db7a9e6a4bb4bffe8b733f5b9036b"},
+    {file = "backports.zoneinfo-0.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:a76b38c52400b762e48131494ba26be363491ac4f9a04c1b7e92483d169f6582"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:8961c0f32cd0336fb8e8ead11a1f8cd99ec07145ec2931122faaac1c8f7fd987"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e81b76cace8eda1fca50e345242ba977f9be6ae3945af8d46326d776b4cf78d1"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7b0a64cda4145548fed9efc10322770f929b944ce5cee6c0dfe0c87bf4c0c8c9"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win32.whl", hash = "sha256:1b13e654a55cd45672cb54ed12148cd33628f672548f373963b0bff67b217328"},
+    {file = "backports.zoneinfo-0.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:4a0f800587060bf8880f954dbef70de6c11bbe59c673c3d818921f042f9954a6"},
+    {file = "backports.zoneinfo-0.2.1.tar.gz", hash = "sha256:fadbfe37f74051d024037f223b8e001611eac868b5c5b06144ef4d8b799862f2"},
 ]
 bcrypt = [
     {file = "bcrypt-3.2.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:7180d98a96f00b1050e93f5b0f556e658605dd9f524d0b0e68ae7944673f525e"},
@@ -2350,10 +2456,7 @@ lockfile = [
     {file = "lockfile-0.12.2-py2.py3-none-any.whl", hash = "sha256:6c3cb24f344923d30b2785d5ad75182c8ea7ac1b6171b08657258ec7429d50fa"},
     {file = "lockfile-0.12.2.tar.gz", hash = "sha256:6aed02de03cba24efabcd600b30540140634fc06cfa603822d508d5361e9f799"},
 ]
-mako = [
-    {file = "Mako-1.2.1-py3-none-any.whl", hash = "sha256:df3921c3081b013c8a2d5ff03c18375651684921ae83fd12e64800b7da923257"},
-    {file = "Mako-1.2.1.tar.gz", hash = "sha256:f054a5ff4743492f1aa9ecc47172cb33b42b9d993cffcc146c9de17e717b0307"},
-]
+mako = []
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
@@ -2403,6 +2506,10 @@ matplotlib-inline = [
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
+]
+mirakuru = [
+    {file = "mirakuru-2.4.2-py3-none-any.whl", hash = "sha256:fdb67d141cc9f7abd485a515d618daf3272c3e6ff48380749997ff8e8c5f2cb2"},
+    {file = "mirakuru-2.4.2.tar.gz", hash = "sha256:ec84d4d81b4bca96cb0e598c6b3d198a92f036a0c1223c881482c02a98508226"},
 ]
 mmh3 = [
     {file = "mmh3-3.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:23912dde2ad4f701926948dd8e79a0e42b000f73962806f153931f52985e1e07"},
@@ -2610,6 +2717,10 @@ poetry-core = [
     {file = "poetry-core-1.0.8.tar.gz", hash = "sha256:951fc7c1f8d710a94cb49019ee3742125039fc659675912ea614ac2aa405b118"},
     {file = "poetry_core-1.0.8-py2.py3-none-any.whl", hash = "sha256:54b0fab6f7b313886e547a52f8bf52b8cf43e65b2633c65117f8755289061924"},
 ]
+port-for = [
+    {file = "port-for-0.6.2.tar.gz", hash = "sha256:9d4e73523d98f2f9f270308bbf415926c698b5439db8909384a79f152328b4d2"},
+    {file = "port_for-0.6.2-py3-none-any.whl", hash = "sha256:be154fdc1d8b2c50820cf1910151e0e9792f82a00ed09b8c277b551e5c99bb5a"},
+]
 pottery = [
     {file = "pottery-3.0.0-py3-none-any.whl", hash = "sha256:0190323bbb1289d40c5cd683feb04c4b8cff76a6c723f3ded9137c8bcc9fb5f8"},
     {file = "pottery-3.0.0.tar.gz", hash = "sha256:adda303e9357442bcac1d4c7f86aa7deec855e0190c101d09448afbcf5676a74"},
@@ -2617,6 +2728,44 @@ pottery = [
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.30-py3-none-any.whl", hash = "sha256:d8916d3f62a7b67ab353a952ce4ced6a1d2587dfe9ef8ebc30dd7c386751f289"},
     {file = "prompt_toolkit-3.0.30.tar.gz", hash = "sha256:859b283c50bde45f5f97829f77a4674d1c1fcd88539364f1b28a37805cfd89c0"},
+]
+psutil = [
+    {file = "psutil-5.9.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:799759d809c31aab5fe4579e50addf84565e71c1dc9f1c31258f159ff70d3f87"},
+    {file = "psutil-5.9.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:9272167b5f5fbfe16945be3db475b3ce8d792386907e673a209da686176552af"},
+    {file = "psutil-5.9.1-cp27-cp27m-win32.whl", hash = "sha256:0904727e0b0a038830b019551cf3204dd48ef5c6868adc776e06e93d615fc5fc"},
+    {file = "psutil-5.9.1-cp27-cp27m-win_amd64.whl", hash = "sha256:e7e10454cb1ab62cc6ce776e1c135a64045a11ec4c6d254d3f7689c16eb3efd2"},
+    {file = "psutil-5.9.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:56960b9e8edcca1456f8c86a196f0c3d8e3e361320071c93378d41445ffd28b0"},
+    {file = "psutil-5.9.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:44d1826150d49ffd62035785a9e2c56afcea66e55b43b8b630d7706276e87f22"},
+    {file = "psutil-5.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c7be9d7f5b0d206f0bbc3794b8e16fb7dbc53ec9e40bbe8787c6f2d38efcf6c9"},
+    {file = "psutil-5.9.1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:abd9246e4cdd5b554a2ddd97c157e292ac11ef3e7af25ac56b08b455c829dca8"},
+    {file = "psutil-5.9.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:29a442e25fab1f4d05e2655bb1b8ab6887981838d22effa2396d584b740194de"},
+    {file = "psutil-5.9.1-cp310-cp310-win32.whl", hash = "sha256:20b27771b077dcaa0de1de3ad52d22538fe101f9946d6dc7869e6f694f079329"},
+    {file = "psutil-5.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:58678bbadae12e0db55186dc58f2888839228ac9f41cc7848853539b70490021"},
+    {file = "psutil-5.9.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:3a76ad658641172d9c6e593de6fe248ddde825b5866464c3b2ee26c35da9d237"},
+    {file = "psutil-5.9.1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a6a11e48cb93a5fa606306493f439b4aa7c56cb03fc9ace7f6bfa21aaf07c453"},
+    {file = "psutil-5.9.1-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:068935df39055bf27a29824b95c801c7a5130f118b806eee663cad28dca97685"},
+    {file = "psutil-5.9.1-cp36-cp36m-win32.whl", hash = "sha256:0f15a19a05f39a09327345bc279c1ba4a8cfb0172cc0d3c7f7d16c813b2e7d36"},
+    {file = "psutil-5.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:db417f0865f90bdc07fa30e1aadc69b6f4cad7f86324b02aa842034efe8d8c4d"},
+    {file = "psutil-5.9.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:91c7ff2a40c373d0cc9121d54bc5f31c4fa09c346528e6a08d1845bce5771ffc"},
+    {file = "psutil-5.9.1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:fea896b54f3a4ae6f790ac1d017101252c93f6fe075d0e7571543510f11d2676"},
+    {file = "psutil-5.9.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3054e923204b8e9c23a55b23b6df73a8089ae1d075cb0bf711d3e9da1724ded4"},
+    {file = "psutil-5.9.1-cp37-cp37m-win32.whl", hash = "sha256:d2d006286fbcb60f0b391741f520862e9b69f4019b4d738a2a45728c7e952f1b"},
+    {file = "psutil-5.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:b14ee12da9338f5e5b3a3ef7ca58b3cba30f5b66f7662159762932e6d0b8f680"},
+    {file = "psutil-5.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:19f36c16012ba9cfc742604df189f2f28d2720e23ff7d1e81602dbe066be9fd1"},
+    {file = "psutil-5.9.1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:944c4b4b82dc4a1b805329c980f270f170fdc9945464223f2ec8e57563139cf4"},
+    {file = "psutil-5.9.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4b6750a73a9c4a4e689490ccb862d53c7b976a2a35c4e1846d049dcc3f17d83b"},
+    {file = "psutil-5.9.1-cp38-cp38-win32.whl", hash = "sha256:a8746bfe4e8f659528c5c7e9af5090c5a7d252f32b2e859c584ef7d8efb1e689"},
+    {file = "psutil-5.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:79c9108d9aa7fa6fba6e668b61b82facc067a6b81517cab34d07a84aa89f3df0"},
+    {file = "psutil-5.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:28976df6c64ddd6320d281128817f32c29b539a52bdae5e192537bc338a9ec81"},
+    {file = "psutil-5.9.1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b88f75005586131276634027f4219d06e0561292be8bd6bc7f2f00bdabd63c4e"},
+    {file = "psutil-5.9.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:645bd4f7bb5b8633803e0b6746ff1628724668681a434482546887d22c7a9537"},
+    {file = "psutil-5.9.1-cp39-cp39-win32.whl", hash = "sha256:32c52611756096ae91f5d1499fe6c53b86f4a9ada147ee42db4991ba1520e574"},
+    {file = "psutil-5.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:f65f9a46d984b8cd9b3750c2bdb419b2996895b005aefa6cbaba9a143b1ce2c5"},
+    {file = "psutil-5.9.1.tar.gz", hash = "sha256:57f1819b5d9e95cdfb0c881a8a5b7d542ed0b7c522d575706a80bedc848c8954"},
+]
+psycopg = [
+    {file = "psycopg-3.0.16-py3-none-any.whl", hash = "sha256:0f5e18920ed978f5063e48acc5ca4389225db7d06a03090d2bbb7a0ec7a640b2"},
+    {file = "psycopg-3.0.16.tar.gz", hash = "sha256:44ca63373c33957ca852fefa1940f8cc5d4c11493b7f6710b0ab250ff5abc50c"},
 ]
 psycopg2 = [
     {file = "psycopg2-2.9.3-cp310-cp310-win32.whl", hash = "sha256:083707a696e5e1c330af2508d8fab36f9700b26621ccbcb538abe22e15485362"},
@@ -2777,6 +2926,10 @@ pytest-flake8 = [
 pytest-isort = [
     {file = "pytest-isort-3.0.0.tar.gz", hash = "sha256:4fe4b26ead2af776730ec23f5870d7421f35aace22a41c4e938586ef4d8787cb"},
     {file = "pytest_isort-3.0.0-py3-none-any.whl", hash = "sha256:2d96a25a135d6fd084ac36878e7d54f26f27c6987c2c65f0d12809bffade9cb9"},
+]
+pytest-postgresql = [
+    {file = "pytest-postgresql-4.1.1.tar.gz", hash = "sha256:144d6af4000641decb1f0e8025d9bfdd4a0572f418c5fec7ef409b51b991295d"},
+    {file = "pytest_postgresql-4.1.1-py3-none-any.whl", hash = "sha256:e4fca93189ce7e4f306ed5974cd5fdbb988f6b18ea51d12465dd301fcace933f"},
 ]
 python-daemon = [
     {file = "python-daemon-2.3.1.tar.gz", hash = "sha256:15c2c5e2cef563e0a5f98d542b77ba59337380b472975d2b2fd6b8c4d5cf46ca"},
@@ -2953,6 +3106,10 @@ types-ujson = [
 typing-extensions = [
     {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
     {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+tzdata = [
+    {file = "tzdata-2022.2-py2.py3-none-any.whl", hash = "sha256:c3119520447d68ef3eb8187a55a4f44fa455f30eb1b4238fa5691ba094f2b05b"},
+    {file = "tzdata-2022.2.tar.gz", hash = "sha256:21f4f0d7241572efa7f7a4fdabb052e61b55dc48274e6842697ccdf5253e5451"},
 ]
 ujson = [
     {file = "ujson-5.4.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:511aa641a5b91d19280183b134fb6c473039d4dd82e987ac810cffba783521ac"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,8 @@ pytest-cov = "^3"
 pytest-flake8 = "^1.0.7"
 pytest-isort = ">=2"
 tox = "^3.24.4"
+psycopg = "^3.0.16"
+pytest-postgresql = "^4.1.1"
 
 [tool.poetry.extras]
 # keep this in sync with the real extras

--- a/tests/app/controllers/test_pool.py
+++ b/tests/app/controllers/test_pool.py
@@ -38,19 +38,19 @@ class TestPool:
             "bar": MockPool(name="bar", **{"fill-level": 64}),
         }
 
-        ipaddr_octet = 1
-        for state, quantity in (("ready", 3), ("deployed", 2)):
-            for idx in range(quantity):
-                ipaddr_octet += 1
-                db_async_session.add(
-                    Node(
-                        hostname=f"node-{ipaddr_octet}",
-                        ipaddr=f"192.168.1.{ipaddr_octet}",
-                        pool="bar",
-                        state=state,
+        async with db_async_session.begin():
+            ipaddr_octet = 1
+            for state, quantity in (("ready", 3), ("deployed", 2)):
+                for idx in range(quantity):
+                    ipaddr_octet += 1
+                    db_async_session.add(
+                        Node(
+                            hostname=f"node-{ipaddr_octet}",
+                            ipaddr=f"192.168.1.{ipaddr_octet}",
+                            pool="bar",
+                            state=state,
+                        )
                     )
-                )
-        await db_async_session.flush()
 
         if pool == "bar":
             expected_status = HTTP_200_OK

--- a/tests/app/test_auth.py
+++ b/tests/app/test_auth.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -8,8 +9,6 @@ from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 from duffy.app.auth import _req_tenant_factory
 from duffy.database.model import Tenant
 from duffy.database.setup import _gen_test_api_key
-
-from ..util import noop_context
 
 
 @pytest.mark.parametrize(
@@ -52,7 +51,7 @@ async def test__req_tenant_factory(testcase, db_async_session, db_async_test_dat
         expectation = pytest.raises(HTTPException)
         exception_args = (HTTP_403_FORBIDDEN,)
     else:
-        expectation = noop_context()
+        expectation = nullcontext()
         exception_args = None
 
     get_req_tenant = _req_tenant_factory(optional="optional" in testcase)

--- a/tests/app/test_main.py
+++ b/tests/app/test_main.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from html.parser import HTMLParser
 from unittest import mock
 
@@ -5,8 +6,6 @@ import pytest
 
 from duffy.app.main import app, init_model, init_tasks, post_process_config
 from duffy.exceptions import DuffyConfigurationError
-
-from ..util import noop_context
 
 
 @pytest.mark.client_auth_as(None)
@@ -53,7 +52,7 @@ class TestMain:
             init_sync_model.side_effect = DuffyConfigurationError("database")
             expectation = pytest.raises(SystemExit)
         else:
-            expectation = noop_context()
+            expectation = nullcontext()
 
         with expectation as excinfo:
             await init_model()

--- a/tests/app/test_util.py
+++ b/tests/app/test_util.py
@@ -1,0 +1,86 @@
+from contextlib import nullcontext
+from unittest import mock
+
+import pytest
+from asyncpg import SerializationError
+from sqlalchemy.exc import DBAPIError
+
+import duffy.app.util
+from duffy.app.util import ConfigRetryContext, SerializationErrorRetryContext
+
+
+def mock_config_get(key, *args, **kwargs):
+    tail = key.rsplit(".", 1)[1]
+
+    return {
+        # just some identifiable values different from the defaults
+        "no-attempts": 2,
+        "delay-min": 0.01,
+        "delay-max": 0.02,
+        "delay-backoff-factor": 3,
+        "delay-add-fuzz": 0.003,
+    }[tail]
+
+
+@pytest.mark.parametrize("with_param", (False, True))
+@mock.patch("duffy.app.util.config_get", mock_config_get)
+async def test_config_retry_context(with_param):
+
+    if with_param:
+        retry = ConfigRetryContext(no_attempts=4)
+    else:
+        retry = ConfigRetryContext()
+
+    if with_param:
+        assert retry.no_attempts == 4
+    else:
+        assert retry.no_attempts == 2
+    assert retry.delay_min == 0.01
+    assert retry.delay_max == 0.02
+    assert retry.delay_backoff_factor == 3
+    assert retry.delay_add_fuzz == 0.003
+
+
+@pytest.mark.parametrize(
+    "testcase",
+    ("matches", "no-match-other-exception", "no-match-other-pgcode", "no-match-no-asyncpg"),
+)
+@mock.patch("duffy.app.util.config_get", mock_config_get)
+async def test_serializationerror_retry_context(testcase):
+    hide_asyncpg = nullcontext()
+
+    orig_exc = mock.MagicMock(spec=SerializationError, pgcode=SerializationError.sqlstate)
+    if "matches" in testcase:
+        expectation = nullcontext()
+    else:
+        expectation = pytest.raises(DBAPIError)
+        if "other-exception" in testcase:
+            orig_exc = mock.MagicMock(spec=RuntimeError)
+        elif "match-other-pgcode" in testcase:
+            orig_exc.pgcode = str(orig_exc.pgcode) + "Boo"
+        elif "no-asyncpg" in testcase:
+            duffy.app.util.asyncpg = None
+            hide_asyncpg = mock.patch.object(duffy.app.util, "asyncpg", None)
+
+    toplvl_exc = DBAPIError("", "", orig_exc)
+
+    mocked_fn = mock.MagicMock()
+    mocked_fn.side_effect = [toplvl_exc, 5]
+
+    async def fn():
+        return mocked_fn()
+
+    result = None
+
+    with expectation, hide_asyncpg:
+        async with SerializationErrorRetryContext() as retry:
+            async for attempt in retry.attempts:
+                try:
+                    result = await fn()
+                except retry.exceptions as exc:
+                    retry.process_exception(exc)
+
+    if "matches" in testcase:
+        assert result == 5
+    else:
+        assert result is None

--- a/tests/client/test_formatters.py
+++ b/tests/client/test_formatters.py
@@ -1,5 +1,6 @@
 import datetime as dt
 import json
+from contextlib import nullcontext
 from enum import Enum
 
 import pytest
@@ -24,8 +25,6 @@ from duffy.client.formatter import (
     DuffyYAMLFormatter,
 )
 from duffy.client.main import DuffyAPIErrorModel
-
-from ..util import noop_context
 
 
 class _TestEnum(str, Enum):
@@ -198,7 +197,7 @@ class TestDuffyFlatFormatter:
         (PoolResult, PoolResultCollection, SessionResult, SessionResultCollection, dict),
     )
     def test_format(self, result_cls):
-        expectation = noop_context()
+        expectation = nullcontext()
         if result_cls == PoolResult:
             api_result = PoolResult(action="get", pool=self.TEST_POOL_VERBOSE)
         elif result_cls == PoolResultCollection:

--- a/tests/client/test_main.py
+++ b/tests/client/test_main.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from http import HTTPStatus
 from json import JSONDecodeError
 from unittest import mock
@@ -17,8 +18,6 @@ from duffy.api_models import (
 from duffy.client import DuffyClient
 from duffy.client.main import _MethodEnum
 from duffy.configuration import config
-
-from ..util import noop_context
 
 
 class InModel(BaseModel):
@@ -124,7 +123,7 @@ class TestDuffyClient:
         Client.return_value = ctxmgr = mock.MagicMock()
         ctxmgr.__enter__.return_value = apiv1_client = mock.MagicMock()
 
-        expectation = noop_context()
+        expectation = nullcontext()
 
         getattr(apiv1_client, http_method).return_value = apiv1_response = mock.MagicMock()
         apiv1_response.status_code = actual_status

--- a/tests/database/test_setup.py
+++ b/tests/database/test_setup.py
@@ -1,10 +1,9 @@
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
 
 from duffy.database import model, setup
-
-from ..util import noop_context
 
 TEST_CONFIG = {
     "database": {
@@ -36,7 +35,7 @@ def test_setup_db_schema(get_sync_engine, inspect, metadata, Config, stamp, db_e
     Config.return_value = cfg
 
     if db_empty:
-        expectation = noop_context()
+        expectation = nullcontext()
     else:
         expectation = pytest.raises(SystemExit)
 

--- a/tests/database/test_util.py
+++ b/tests/database/test_util.py
@@ -1,4 +1,5 @@
 import datetime as dt
+from contextlib import nullcontext
 
 import pytest
 from sqlalchemy import Column, Integer, select
@@ -6,8 +7,6 @@ from sqlalchemy.exc import StatementError
 
 from duffy.database import Base
 from duffy.database.util import CreatableMixin, DeclEnum, RetirableMixin, TZDateTime
-
-from ..util import noop_context
 
 
 class UselessEnum(DeclEnum):
@@ -72,7 +71,7 @@ class TestTZDateTime:
         """Test the process_bind_param() method."""
         obj = TZDateTime()
 
-        expectation = noop_context()
+        expectation = nullcontext()
 
         if testcase == "none":
             now = None

--- a/tests/database/test_util.py
+++ b/tests/database/test_util.py
@@ -11,8 +11,8 @@ from ..util import noop_context
 
 
 class UselessEnum(DeclEnum):
-    enval1 = "Enum value 1"
-    enval2 = "Enum value 2"
+    enval1 = "enval1"
+    enval2 = "enval2"
 
 
 class UselessThing(Base):

--- a/tests/nodes/test_mechanisms.py
+++ b/tests/nodes/test_mechanisms.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -5,8 +6,6 @@ import pytest
 from duffy.nodes.mechanisms.ansible import AnsibleMechanism, PlaybookType
 from duffy.nodes.mechanisms.main import Mechanism, MechanismFailure
 from duffy.nodes.pools import ConcreteNodePool, NodePool
-
-from ..util import noop_context
 
 
 @mock.patch.dict(Mechanism.known_mechanisms, clear=True)
@@ -151,7 +150,7 @@ class TestAnsibleMechanism:
                 del run.events[-2]["event_data"]
                 expectation = pytest.raises(MechanismFailure)
             else:
-                expectation = noop_context()
+                expectation = nullcontext()
 
         with expectation:
             args = (PlaybookType.provision, "bloop")

--- a/tests/tasks/test_deprovision.py
+++ b/tests/tasks/test_deprovision.py
@@ -1,5 +1,6 @@
 import logging
 from collections import defaultdict
+from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
 
@@ -10,8 +11,6 @@ from duffy.database.model import Node
 from duffy.nodes.mechanisms import MechanismFailure
 from duffy.nodes.pools import ConcreteNodePool, NodePool
 from duffy.tasks import deprovision
-
-from ..util import noop_context
 
 HERE = Path(__file__).parent
 PLAYBOOK_PATH = HERE / "playbooks"
@@ -35,7 +34,7 @@ PLAYBOOK_PATH = HERE / "playbooks"
     ),
 )
 def test_deprovision_pool_nodes(testcase, test_mechanism, db_sync_session, caplog):
-    expectation = noop_context()
+    expectation = nullcontext()
     real_playbook = "real-playbook" in testcase
 
     if "unknown-pool" in testcase:

--- a/tests/tasks/test_expire.py
+++ b/tests/tasks/test_expire.py
@@ -1,17 +1,16 @@
 import datetime as dt
 import uuid
+from contextlib import nullcontext
 from unittest import mock
 
 from duffy.database.model import Node, Session, SessionNode, Tenant
 from duffy.tasks import expire_sessions
 
-from ..util import noop_context
-
 
 @mock.patch("duffy.tasks.expire.deprovision_nodes")
 @mock.patch("duffy.tasks.expire.Lock")
 def test_expire_sessions(Lock, deprovision_nodes, db_sync_session, caplog):
-    Lock.return_value = noop_context()
+    Lock.return_value = nullcontext()
     deprovision_nodes.delay.return_value = async_result = mock.Mock()
 
     with db_sync_session.begin():

--- a/tests/tasks/test_provision.py
+++ b/tests/tasks/test_provision.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from pathlib import Path
 from unittest import mock
 
@@ -8,8 +9,6 @@ from duffy.database.model import Node
 from duffy.nodes.mechanisms import Mechanism, MechanismFailure
 from duffy.nodes.pools import ConcreteNodePool
 from duffy.tasks import provision
-
-from ..util import noop_context
 
 HERE = Path(__file__).parent
 PLAYBOOK_PATH = HERE / "playbooks"
@@ -109,7 +108,7 @@ def test_provision_nodes_into_pool(reuse_nodes, testcase, foo_pool, db_sync_sess
 
     supplied_node_ids = created_node_ids
 
-    expectation = noop_context()
+    expectation = nullcontext()
 
     if "unknown-pool" in testcase:
         pool_name = "bar"
@@ -281,7 +280,7 @@ def test_fill_single_pool(
     Lock, provision_nodes_into_pool, testcase, db_sync_session, foo_pool, caplog
 ):
     """Test the fill_single_pool() task."""
-    Lock.return_value = noop_context()
+    Lock.return_value = nullcontext()
 
     if "run-once" in testcase:
         foo_pool["run-parallel"] = False
@@ -336,7 +335,7 @@ def test_fill_single_pool(
         if "broken-spec" in testcase:
             expectation = pytest.raises(RuntimeError, match=r"\[foo\] Skipping filling up")
         else:
-            expectation = noop_context()
+            expectation = nullcontext()
     else:
         pool_name = "bar"
         expectation = pytest.raises(RuntimeError, match=r"\[bar\] Unknown pool, bailing out")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,4 +1,5 @@
 import uuid
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -10,8 +11,6 @@ from duffy.admin import AdminContext
 from duffy.app import controllers
 from duffy.database.model import Tenant
 from duffy.exceptions import DuffyConfigurationError
-
-from .util import noop_context
 
 
 @pytest.fixture
@@ -37,7 +36,7 @@ class TestAdminContext:
     @mock.patch.object(AdminContext, "__new__")
     def test_create_for_cli(self, admin_ctx_new, testcase, caplog):
         if testcase == "success":
-            expectation = noop_context()
+            expectation = nullcontext()
             admin_ctx_new.return_value = sentinel = object()
         elif testcase == "config-error":
             admin_ctx_new.side_effect = DuffyConfigurationError("BOO")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+from contextlib import nullcontext
 from datetime import timedelta
 from unittest import mock
 from uuid import uuid4
@@ -16,8 +17,6 @@ from duffy.configuration import config
 from duffy.exceptions import DuffyConfigurationError
 from duffy.util import UNSET
 from duffy.version import __version__
-
-from .util import noop_context
 
 
 @pytest.fixture
@@ -84,7 +83,7 @@ class TestNodesSpecType:
             expectation = pytest.raises(BadParameter)
         else:
             value = "pool=test,quantity=1"
-            expectation = noop_context()
+            expectation = nullcontext()
 
         with expectation:
             converted = duffy.cli.NODES_SPEC.convert(value, None, None)
@@ -323,7 +322,7 @@ def test_serve(uvicorn_run, testcase, runner, duffy_config_files, tmp_path):
     if "missing-modules" in testcase:
         ctxmgr = mock.patch.object(duffy.cli, "uvicorn", None)
     else:
-        ctxmgr = noop_context()
+        ctxmgr = nullcontext()
 
     parameters = (f"--config={config_file.absolute()}", "serve")
 
@@ -363,7 +362,7 @@ def test_serve_legacy(uvicorn_run, testcase, runner, duffy_config_files, tmp_pat
     if "missing-modules" in testcase:
         ctxmgr = mock.patch.object(duffy.cli, "uvicorn", None)
     else:
-        ctxmgr = noop_context()
+        ctxmgr = nullcontext()
 
     parameters = (f"--config={config_file.absolute()}", "serve-legacy")
 

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -66,3 +66,16 @@ class TestConfiguration:
         main.read_configuration(partial_config_file, clear=True, validate=False)
         main.read_configuration(*duffy_config_files, clear=False, validate=False)
         main.read_configuration(clear=False, validate=True)
+
+
+@pytest.mark.duffy_config(EXAMPLE_CONFIG, clear=True)
+@pytest.mark.parametrize(
+    "keys,result",
+    (
+        (("app.host",), "127.0.0.1"),
+        (("defaults.port", "app.port"), 8080),
+        (("foo",), "test-default"),
+    ),
+)
+def test_config_get(keys, result):
+    assert main.config_get(*keys, default="test-default") == result

--- a/tests/test_legacy.py
+++ b/tests/test_legacy.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from typing import Iterator
 from unittest import mock
 
@@ -17,8 +18,6 @@ from duffy.configuration import config
 from duffy.legacy import main
 from duffy.legacy.api_models import Credentials
 from duffy.legacy.auth import _req_credentials_factory
-
-from .util import noop_context
 
 TEST_CRED = Credentials(
     username="hahahahahatheystoppedlegacysupporthahahahaha",
@@ -62,7 +61,7 @@ class TestAuth:
             expectation = pytest.raises(HTTPException)
             exception_args = (HTTP_403_FORBIDDEN,)
         else:
-            expectation = noop_context()
+            expectation = nullcontext()
             exception_args = None
 
         get_req_credentials = _req_credentials_factory(optional="optional" in testcase)

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,3 +1,4 @@
+from contextlib import nullcontext
 from unittest import mock
 
 import pytest
@@ -6,8 +7,6 @@ from sqlalchemy.orm import Session
 
 from duffy import exceptions, shell
 from duffy.database import model
-
-from .util import noop_context
 
 
 @pytest.mark.parametrize("with_ipython", (True, False))
@@ -102,7 +101,7 @@ def test_embed_shell(get_available_shells, embed_python_shell, embed_ipython_she
         get_available_shells.return_value = ["default"]
         expectation = pytest.raises(exceptions.DuffyShellUnavailableError, match="default")
     else:
-        expectation = noop_context()
+        expectation = nullcontext()
 
     with expectation:
         shell.embed_shell(shell_type=shell_type)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,9 +1,11 @@
+import logging
 from contextlib import nullcontext
 from typing import List, Tuple, Union
+from unittest import mock
 
 import pytest
 
-from duffy.util import camel_case_to_lower_with_underscores, merge_dicts
+from duffy.util import RetryContext, camel_case_to_lower_with_underscores, merge_dicts
 
 
 @pytest.mark.parametrize(
@@ -42,3 +44,117 @@ class TestMergeDicts:
 
         if isinstance(expected, dict):
             assert expected == result
+
+
+class TestRetryContext:
+    def test___init___with_params(self):
+        with RetryContext(
+            exceptions=RuntimeError,
+            no_attempts=1,
+            delay_min=2,
+            delay_max=3,
+            delay_backoff_factor=4,
+            delay_add_fuzz=5,
+        ) as retry:
+            assert retry.exceptions == RuntimeError
+            assert retry.no_attempts == 1
+            assert retry.delay_min == 2
+            assert retry.delay_max == 3
+            assert retry.delay_backoff_factor == 4
+            assert retry.delay_add_fuzz == 5
+
+    @pytest.mark.parametrize("testcase", ("success", "exhausted"))
+    @mock.patch("duffy.util.time.sleep")
+    def test_sync(self, sleep, testcase, caplog):
+        caplog.set_level(logging.DEBUG)
+        if testcase == "success":
+            limit = 3
+            expectation = nullcontext()
+        else:
+            limit = 6
+            expectation = pytest.raises(RuntimeError)
+
+        result = None
+
+        with expectation:
+            with RetryContext() as retry:
+                for attempt in retry.attempts:
+                    try:
+                        if attempt < limit:
+                            raise RuntimeError()
+                        result = attempt
+                    except retry.exceptions as exc:
+                        retry.process_exception(exc)
+
+        if testcase == "success":
+            assert result == limit
+        else:
+            assert result is None
+
+        assert sleep.call_count == min(4, limit - 1)
+
+    @pytest.mark.parametrize("testcase", ("success", "exhausted"))
+    @mock.patch("duffy.util.asyncio.sleep")
+    async def test_async(self, sleep, testcase):
+        if testcase == "success":
+            limit = 3
+            expectation = nullcontext()
+        else:
+            limit = 6
+            expectation = pytest.raises(RuntimeError)
+
+        result = None
+
+        with expectation:
+            async with RetryContext() as retry:
+                async for attempt in retry.attempts:
+                    try:
+                        if attempt < limit:
+                            raise RuntimeError()
+                        result = attempt
+                    except retry.exceptions as exc:
+                        retry.process_exception(exc)
+
+        if testcase == "success":
+            assert result == 3
+        else:
+            assert result is None
+
+        assert sleep.await_count == min(4, limit - 1)
+
+    @pytest.mark.parametrize("testcase", ("success", "no-match"))
+    @mock.patch("duffy.util.time.sleep")
+    def test_exception_matches(self, sleep, testcase):
+        class MyRetryContext(RetryContext):
+            def exception_matches(self, exc):
+                if not super().exception_matches(exc):
+                    return False
+
+                return exc.args and "FOO" in exc.args[0]
+
+        if testcase == "success":
+            expectation = nullcontext()
+        else:
+            expectation = pytest.raises(RuntimeError)
+
+        result = None
+
+        with expectation:
+            with MyRetryContext() as retry:
+                for attempt in retry.attempts:
+                    try:
+                        if attempt < 3:
+                            if testcase == "no-match":
+                                raise RuntimeError()
+                            else:
+                                raise RuntimeError("Find this: >>> FOO <<<")
+                        result = attempt
+                    except retry.exceptions as exc:
+                        retry.process_exception(exc)
+
+        if testcase == "success":
+            assert result == 3
+            assert sleep.call_count == 2
+        else:
+            assert result is None
+            assert sleep.call_count == 0

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,10 +1,9 @@
+from contextlib import nullcontext
 from typing import List, Tuple, Union
 
 import pytest
 
 from duffy.util import camel_case_to_lower_with_underscores, merge_dicts
-
-from .util import noop_context
 
 
 @pytest.mark.parametrize(
@@ -36,7 +35,7 @@ class TestMergeDicts:
         if isinstance(expected, type) and issubclass(expected, Exception):
             expectation = pytest.raises(expected)
         else:
-            expectation = noop_context()
+            expectation = nullcontext()
 
         with expectation:
             result = merge_dicts(*input_dicts)

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,8 +1,0 @@
-from contextlib import contextmanager
-from typing import Any
-
-
-@contextmanager
-def noop_context(context_value: Any = None):
-    """An 'empty' context manager, can be used as a stand-in."""
-    yield context_value

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ isolated_build = true
 skip_missing_interpreters = true
 
 [testenv]
+setenv =
+    COV_FAIL_UNDER = 100
 skip_install = true
 sitepackages = false
 whitelist_externals = poetry
@@ -12,7 +14,12 @@ commands =
   poetry install -E all
   pip install pytest-xdist
   duffy --version
-  pytest -o 'addopts=--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html' -n auto tests/
+  pytest -o 'addopts=--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html -n auto --cov-fail-under {env:COV_FAIL_UNDER}' tests/
+
+[testenv:py39]
+# Python 3.9 fails tracing an async generator to its completion in create_session()
+setenv =
+    COV_FAIL_UNDER = 99
 
 [testenv:black]
 commands =


### PR DESCRIPTION
```
commit f2097057849d998124f2c15340e8675f5c45f642
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 4 11:28:15 2022 +0200

    Configuration: Don't trip over empty YAML files
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 0acba76ac451e2fe749c266fa680997cdf55f410
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Aug 16 22:32:42 2022 +0200

    Rework CI jobs
    
    This splits out black, flake8, isort into their own job to avoid running
    them for every Python version and uses the Fedora Python container image
    to run tests.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit a43e96a4fdc557fdf1a468e48792ab8250193741
Author: Nils Philippsen <nils@redhat.com>
Date:   Tue Aug 9 11:19:18 2022 +0200

    Use PostgreSQL for testing
    
    This makes testing slower (it stands up a PostgreSQL server for each
    test function) but is necessary to test concurrency issues.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit a7da74c432fc96fb9e15b10bde90a771f16882f0
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Aug 15 17:28:09 2022 +0200

    Use contextlib.nullcontext rather than home-grown
    
    It's been here all the time and didn't say a word... *rolls eyes*
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit b0ff10ff6a16387c10b829dc7ac8037ed3bc5ee6
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Aug 15 17:47:40 2022 +0200

    Add config_get()
    
    This function gets configuration items from several alternative places,
    e.g. one specific to the app, a default from configuration, or a
    hard-coded fallback value.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit de3ec6a1ba465347fa04e2f3db2b7912f1695945
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 18 14:17:43 2022 +0200

    Clean up private data dir of ansible-runner
    
    Previously, these were left around which was filling up inodes on the
    machine running task workers.
    
    Fixes: #554
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 57108c0d2d2c58586b16ffdf429d92efe68f66c7
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Aug 15 17:51:30 2022 +0200

    Retry creating session on DB serialization errors
    
    This is necessary because concurrent API calls would all select on the
    same set of node objects in separate transactions which fails for every
    call but one. Now, create_session() retries the affected code block a
    number of times in the case of such an error before it actually flags an
    error.
    
    Fixes: #523
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```