### PR TITLE
Ensure admin changes are persisted to the database

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -31,11 +31,6 @@ jobs:
         run: |
           dnf install -y libpq-devel postgresql-server
 
-      - name: Install base Python dependencies
-        run: |
-          python3 -m pip install --upgrade poetry
-          python3 -m pip install --upgrade tox
-
       - name: Set up testrunner user
         run: |
           useradd testrunner

--- a/duffy/admin.py
+++ b/duffy/admin.py
@@ -38,12 +38,13 @@ class AdminContext:
             return admin_ctx
 
     async def proxy_controller_function_async(self, controller_function, **kwargs):
-        async with async_session_maker() as db_async_session:
+        async with async_session_maker() as db_async_session, db_async_session.begin():
             try:
                 return await controller_function(
                     tenant=self.fake_api_tenant, db_async_session=db_async_session, **kwargs
                 )
             except HTTPException as exc:
+                await db_async_session.rollback()
                 return {"error": {"detail": exc.detail}}
 
     def proxy_controller_function(self, controller_function, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,8 @@ skip_install = true
 sitepackages = false
 whitelist_externals = poetry
 commands =
+  pip install -U poetry pytest-xdist
   poetry install -E all
-  pip install pytest-xdist
   duffy --version
   pytest -o 'addopts=--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html -n auto --cov-fail-under {env:COV_FAIL_UNDER}' tests/
 


### PR DESCRIPTION
With recent changes to the transaction isolation level in the API
server, changes done through the `duffy admin` commands weren’t
committed to the database anymore because they weren’t committed
explicitly so far.

Fixes: #581

Signed-off-by: Nils Philippsen <nils@redhat.com>