### PR TITLE
Don’t use pytest-flake8

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2549,22 +2549,6 @@ pytest = ">=4.6"
 testing = ["fields", "hunter", "process-tests", "pytest-xdist", "six", "virtualenv"]
 
 [[package]]
-name = "pytest-flake8"
-version = "1.1.1"
-description = "pytest plugin to check FLAKE8 requirements"
-category = "dev"
-optional = false
-python-versions = "*"
-files = [
-    {file = "pytest-flake8-1.1.1.tar.gz", hash = "sha256:ba4f243de3cb4c2486ed9e70752c80dd4b636f7ccb27d4eba763c35ed0cd316e"},
-    {file = "pytest_flake8-1.1.1-py2.py3-none-any.whl", hash = "sha256:e0661a786f8cbf976c185f706fdaf5d6df0b1667c3bcff8e823ba263618627e7"},
-]
-
-[package.dependencies]
-flake8 = ">=4.0"
-pytest = ">=7.0"
-
-[[package]]
 name = "pytest-isort"
 version = "3.1.0"
 description = "py.test plugin to check import ordering using isort"
@@ -3485,4 +3469,4 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "cdc3a59de30999d9fe6b33d16a8c0dd8eddbdaa5a2d5d0cf040414243edb61b1"
+content-hash = "54e3f3a90144e57f5e32313a3a4972922827844825ba1b2cfd202a7c69ad7c96"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,6 @@ pytest = ">=6.2.5"
 pytest-asyncio = ">=0.17, <2"
 pytest-black = ">=0.3.12, <2"
 pytest-cov = "^3 || ^4"
-pytest-flake8 = "^1.0.7"
 pytest-isort = ">=2"
 tox = "^3.24.4 || ^4.0.0"
 psycopg = "^3.0.16"
@@ -103,8 +102,7 @@ legacy = ["httpx", "Jinja2"]
 client = ["httpx"]
 
 [tool.pytest.ini_options]
-addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --flake8 --isort"
-flake8-max-line-length = 100
+addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --isort"
 asyncio_mode = "auto"
 
 [tool.isort]


### PR DESCRIPTION
This pytest plugin doesn’t seem to be maintained and isn’t compatible with current versions of flake8.