### PR TITLE
Make compatible with SQLAlchemy version 2

### DIFF
--- a/duffy/database/model/tenant.py
+++ b/duffy/database/model/tenant.py
@@ -52,7 +52,7 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     @effective_node_quota.expression
     def effective_node_quota(cls):
         return case(
-            [(cls.node_quota != None, cls.node_quota)],  # noqa: E711
+            (cls.node_quota != None, cls.node_quota),  # noqa: E711
             else_=_defaults_config().node_quota,
         )
 
@@ -66,7 +66,7 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     @effective_session_lifetime.expression
     def effective_session_lifetime(cls):
         return case(
-            [(cls.session_lifetime != None, cls.session_lifetime)],  # noqa: E711
+            (cls.session_lifetime != None, cls.session_lifetime),  # noqa: E711
             else_=_defaults_config().session_lifetime,
         )
 
@@ -80,6 +80,6 @@ class Tenant(Base, CreatableMixin, RetirableMixin):
     @effective_session_lifetime_max.expression
     def effective_session_lifetime_max(cls):
         return case(
-            [(cls.session_lifetime_max != None, cls.session_lifetime_max)],  # noqa: E711
+            (cls.session_lifetime_max != None, cls.session_lifetime_max),  # noqa: E711
             else_=_defaults_config().session_lifetime_max,
         )

--- a/poetry.lock
+++ b/poetry.lock
@@ -3469,4 +3469,4 @@ tasks = ["aiodns", "ansible-runner", "Jinja2", "jmespath", "pottery", "celery"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "54e3f3a90144e57f5e32313a3a4972922827844825ba1b2cfd202a7c69ad7c96"
+content-hash = "111b4672098f0151660f81a3e7fd985054b5e3d2b0a0e7a49e2369f2712951af"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ classifiers = [
 python = "^3.8"
 click = "^8.0.3"
 PyYAML = "^6"
-SQLAlchemy = {version = "^1.4.25 || ^2.0.0", extras=["asyncio"], optional = true}
+SQLAlchemy = {version = "^1.4.25 || ^2.0.5", extras=["asyncio"], optional = true}
 alembic = {version = "^1.7.5", optional = true}
 bcrypt = {version = "^3.2 || ^4", optional = true}
 fastapi = {version = ">=0.70, <2", optional = true}


### PR DESCRIPTION
Formerly, case() would accept a sequence of conditions as one positional parameter. Version 2.0 requires each condition to be passed as its own positional parameter.

Exclude versions before 2.0.5 because of a regression in MutableDict, see https://github.com/sqlalchemy/sqlalchemy/issues/9380 for details.