### PR TITLE
Set allowed version ranges of dependencies tighter

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3249,4 +3249,4 @@ tasks = ["Jinja2", "aiodns", "ansible-runner", "celery", "jmespath", "pottery"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "bd72318f38cda5c531f60fb16eb2d109c8e8af9fb034c30b57e9f1854b06a5a2"
+content-hash = "18038c53a2cd86c76c4848cc4ce24521eb8e9582e989bec7955f862f098c74f2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,39 +41,39 @@ PyYAML = "^6"
 SQLAlchemy = {version = "^2.0.5", extras=["asyncio"], optional = true}
 alembic = {version = "^1.7.5", optional = true}
 bcrypt = {version = "^3.2 || ^4", optional = true}
-fastapi = {version = ">=0.70, <2", optional = true}
-uvicorn = {version = ">=0.15, <2", optional = true}
+fastapi = {version = "^0.70 || ^0.71 || ^0.72 || ^0.73 || ^0.74 || ^0.75 || ^0.76 || ^0.77 || ^0.78 || ^0.79 || ^0.80 || ^0.81 || ^0.82 || ^0.83 || ^0.84 || ^0.85 || ^0.86 || ^0.87 || ^0.88 || ^0.89 || ^0.90 || ^0.91 || ^0.92 || ^0.93 || ^0.94 || ^0.95 || ^0.96 || ^0.97 || ^0.98", optional = true}
+uvicorn = {version = "^0.15 || ^0.16 || ^0.17 || ^0.18 || ^0.19 || ^0.20 || ^0.21 || ^0.22", optional = true}
 Jinja2 = {version = "^3.0.3", optional = true}
 ansible-runner = {version = "^2.1.1", optional = true}
-asyncpg = {version = ">=0.25, <2", optional = true}
+asyncpg = {version = "^0.25 || ^0.26 || ^0.27 || ^0.28", optional = true}
 celery = {version = "^5.2.1", extras = ["redis"], optional = true}
-httpx = {version = ">=0.18.2, <2", optional = true}
-ipython = {version = ">=7.29", optional = true}
-jmespath = {version = ">=0.10, <2", optional = true}
+httpx = {version = "^0.18.2 || ^0.19 || ^0.20 || ^0.21 || ^0.22 || ^0.23 || ^0.24", optional = true}
+ipython = {version = "^7.29 || ^8", optional = true}
+jmespath = {version = "^0.10 || ^1", optional = true}
 pottery = {version = "^3", optional = true}
 psycopg2 = {version = "^2.9.2", optional = true}
 aiodns = {version = "^3.0.0", optional = true}
-pydantic = ">=1.6.2, <2"
-aiosqlite = {version = ">=0.17.0, <2", optional = true}
-pyxdg = ">=0.27, <2"
+pydantic = "^1.6.2"
+aiosqlite = {version = "^0.17 || ^0.18 || ^0.19", optional = true}
+pyxdg = "^0.27 || ^0.28"
 
 [tool.poetry.dev-dependencies]
 Jinja2 = "^3.0.3"
 ansible = "^5.2 || ^6 || ^7.0.0 || ^8.0.0"
 ansible-core = "^2.12.1"
 ansible-runner = "^2.1.1"
-black = ">=21.9b0"
-flake8 = ">=3.9.2"
-httpx = ">=0.18.2, <2"
+black = "^21.9b0 || ^22 || ^23"
+flake8 = "^3.9.2 || ^4 || ^5"
+httpx = "^0.18.2 || ^0.19 || ^0.20 || ^0.21 || ^0.22 || ^0.23 || ^0.24"
 isort = "^5.9.3"
-jmespath = ">=0.10, <2"
+jmespath = "^0.10 || ^1"
 poetry = "^1.2.0"
 pottery = "^3"
 pytest = ">=6.2.5"
-pytest-asyncio = ">=0.17, <2"
-pytest-black = ">=0.3.12, <2"
+pytest-asyncio = "^0.17 || ^0.18 || ^0.19 || ^0.20 || ^0.21"
+pytest-black = "^0.3.12"
 pytest-cov = "^3 || ^4"
-pytest-isort = ">=2"
+pytest-isort = "^2 || ^3"
 tox = "^3.24.4 || ^4.0.0"
 psycopg = "^3.0.16"
 pytest-postgresql = "^4.1.1 || ^5.0.0"


### PR DESCRIPTION
Prior to using Renovate to take care of dependency updates, we used Dependabot which didn’t submit PRs for major version upgrades of dependencies. With version specifications of the format "^0.y.z", Poetry only accepts new versions that bump the least significant digit of the specification as fulfilling the spec.

Fixes: #866