### PR TITLE
Revamp creating sessions and related

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,8 +3,6 @@ branch = True
 source = duffy
 omit =
 concurrency = greenlet
-plugins =
-  coverage_conditional_plugin
 
 [report]
 precision = 2
@@ -14,8 +12,3 @@ exclude_lines =
     def __repr__
     if TYPE_CHECKING:
 show_missing = True
-
-[coverage_conditional_plugin]
-rules =
-    "'PYTEST_XDIST_WORKER' in os_environ": with-xdist
-    "'PYTEST_XDIST_WORKER' not in os_environ": without-xdist

--- a/duffy/app/controllers/session.py
+++ b/duffy/app/controllers/session.py
@@ -35,7 +35,7 @@ router = APIRouter(prefix="/sessions")
 
 
 def wrap_with_http_422_exception(exc: Exception) -> Exception:
-    return HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, str(exc))  # pragma: without-xdist
+    return HTTPException(HTTP_422_UNPROCESSABLE_ENTITY, str(exc))
 
 
 # http get http://localhost:8080/api/v1/sessions
@@ -188,7 +188,7 @@ async def create_session(
                             session_nodes.append(session_node)
                             db_async_session.add(session_node)
                             log.debug("Allocating node: %s (%s)", node.id, node.pool)
-            except retry.exceptions as exc:  # pragma: without-xdist
+            except retry.exceptions as exc:
                 retry.process_exception(exc)
 
     # Unfortunately, it is possible that the read operations on nodes above (in another concurrent
@@ -294,7 +294,7 @@ async def create_session(
                     # None not in contextualized_ipaddrs
                     # Workaround: give coverage an anchor to detect that this branch is taken.
                     pass
-            except retry.exceptions as exc:  # pragma: without-xdist
+            except retry.exceptions as exc:
                 retry.process_exception(exc)
 
     log.debug("Nodes deployed, kick off filling pools and return result via API")

--- a/duffy/database/migrations/versions/6654d536b836_add_node_state_sessionnode_session_id_.py
+++ b/duffy/database/migrations/versions/6654d536b836_add_node_state_sessionnode_session_id_.py
@@ -1,0 +1,25 @@
+"""Add Node.state, SessionNode.session_id indexes
+
+Revision ID: 6654d536b836
+Revises: 36cf064c0481
+Create Date: 2023-09-06 21:42:56.647045
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "6654d536b836"
+down_revision = "36cf064c0481"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_index(op.f("nodes_state_index"), "nodes", ["state"], unique=False)
+    op.create_index(
+        op.f("sessions_nodes_session_id_index"), "sessions_nodes", ["session_id"], unique=False
+    )
+
+
+def downgrade():
+    op.drop_index(op.f("sessions_nodes_session_id_index"), table_name="sessions_nodes")
+    op.drop_index(op.f("nodes_state_index"), table_name="nodes")

--- a/duffy/database/model/node.py
+++ b/duffy/database/model/node.py
@@ -44,6 +44,7 @@ class Node(Base, CreatableMixin, RetirableMixin):
         nullable=False,
         default=NodeState.unused,
         server_default=NodeState.unused.value,
+        index=True,
     )
     comment = Column(UnicodeText, nullable=True)
 
@@ -64,7 +65,9 @@ class Node(Base, CreatableMixin, RetirableMixin):
 
 class SessionNode(Base):
     __tablename__ = "sessions_nodes"
-    session_id = Column(Integer, ForeignKey(Session.id), primary_key=True, nullable=False)
+    session_id = Column(
+        Integer, ForeignKey(Session.id), primary_key=True, nullable=False, index=True
+    )
     session = relationship(Session, back_populates="session_nodes")
     node_id = Column(Integer, ForeignKey(Node.id), primary_key=True, nullable=False)
     node = relationship(Node)

--- a/duffy/util.py
+++ b/duffy/util.py
@@ -131,6 +131,15 @@ class RetryContext:
         if delay_add_fuzz is not None:
             self.delay_add_fuzz = delay_add_fuzz
 
+    def __repr__(self):
+        pieces = [
+            f"{name}={value!r}"
+            for name in ("exceptions", "no_attempts")
+            for value in (getattr(self, name),)
+            if value is not None
+        ]
+        return f"{type(self).__name__}({', '.join(pieces)})"
+
     def __enter__(self):
         self._is_async = False
         self._exc = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -830,22 +830,6 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
-name = "coverage-conditional-plugin"
-version = "0.9.0"
-description = "Conditional coverage based on any rules you define!"
-optional = false
-python-versions = ">=3.7,<4.0"
-files = [
-    {file = "coverage_conditional_plugin-0.9.0-py3-none-any.whl", hash = "sha256:1b37bc469019d2ab5b01f5eee453abe1846b3431e64e209720c2a9ec4afb8130"},
-    {file = "coverage_conditional_plugin-0.9.0.tar.gz", hash = "sha256:6893dab0542695dbd5ea714281dae0dfec8d0e36480ba32d839e9fa7344f8215"},
-]
-
-[package.dependencies]
-coverage = ">=7,<8"
-importlib_metadata = {version = "*", markers = "python_version < \"3.10\""}
-packaging = ">=20.4"
-
-[[package]]
 name = "crashtest"
 version = "0.4.1"
 description = "Manage Python errors with ease"
@@ -3214,4 +3198,4 @@ tasks = ["Jinja2", "aiodns", "ansible-runner", "celery", "jmespath", "pottery"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "2cec52f188d166f89382dfc385bee07b95b1788359d9d0765ccc3ca08b4f0e40"
+content-hash = "f0240fd1803ee439ddc45f3dd8094a66819a54bb11518123331483d178ff86cd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,6 @@ pytest-isort = "^2 || ^3"
 tox = "^3.24.4 || ^4.0.0"
 psycopg = "^3.0.16"
 pytest-postgresql = "^4.1.1 || ^5.0.0"
-coverage-conditional-plugin = "^0.8.0 || ^0.9.0"
 
 [tool.poetry.extras]
 # the `serve` command

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import psycopg
 import pytest
 import pytest_postgresql
 import yaml
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.engine.url import URL
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -16,6 +16,7 @@ from duffy.app.logging import RequestIdFilter
 from duffy.configuration import read_configuration
 from duffy.database import (
     Base,
+    _pgsql_disable_seqscan,
     async_session_maker,
     init_async_model,
     init_sync_model,
@@ -159,6 +160,7 @@ def db_sync_engine(postgresql_sync_url):
         echo=True,
         isolation_level="SERIALIZABLE",
     )
+    event.listen(db_engine, "connect", _pgsql_disable_seqscan)
     return db_engine
 
 
@@ -171,6 +173,7 @@ def db_async_engine(postgresql_async_url):
         echo=True,
         isolation_level="SERIALIZABLE",
     )
+    event.listen(async_db_engine.sync_engine, "connect", _pgsql_disable_seqscan)
     return async_db_engine
 
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -62,6 +62,10 @@ class TestRetryContext:
             assert retry.delay_backoff_factor == 4
             assert retry.delay_add_fuzz == 5
 
+            assert repr(retry) == (
+                f"RetryContext(exceptions={retry.exceptions}, no_attempts={retry.no_attempts})"
+            )
+
     @pytest.mark.parametrize("testcase", ("success", "exhausted"))
     @mock.patch("duffy.util.time.sleep")
     def test_sync(self, sleep, testcase, caplog):

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ commands =
   poetry install --all-extras
   pip install pytest-xdist
   duffy --version
-  pytest -o 'addopts=--no-cov' tests/app/controllers/test_session.py::TestSessionWorkflow::test_request_session_concurrently
   pytest -o 'addopts=--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html -n auto --cov-fail-under {env:COV_FAIL_UNDER}' tests/
 
 [testenv:py39]


### PR DESCRIPTION
Fix creating sessions concurrently 🤞 and related changes. 

```
commit 0f9b7f1ad99bfcc8fca5aa1f84228dba041bee36
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Sep 6 12:17:28 2023 +0200

    Test get_{sync,async}_engine() more thoroughly
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 7d7ec05cb72aa25048de1ca24c1c5a62f36c1495
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 24 15:14:02 2023 +0200

    Implement repr() for RetryContext objects
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit e6ad8db2c92c5d7cea340319be96a89f32d8f3bc
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 24 15:19:21 2023 +0200

    RetryContext: Allow re-wrapping exceptions
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 4ff636fd57effcbb5246c05e253fa58c9c81444b
Author: Nils Philippsen <nils@redhat.com>
Date:   Thu Aug 24 15:20:16 2023 +0200

    Revamp creating sessions
    
    - Return HTTP code 422 (unprocessable entity) if nodes are ultimately
      failed to be allocated for the new session.
    - Use (only) two separate transactions which get retried on DB
      conflicts. It is necessary to retry even the second transaction: even
      though the nodes used there are exclusive (allocated to the session in
      question), the query used to allocate nodes elsewhere can get their
      rows read, which can lead to conflicts.
    - Separate these transactions better by reloading all necessary objects
      from the database.
    - Return appropriate HTTP codes on failures.
    - Really unallocate nodes/delete the session on contextualization failures.
    
    Fixes: #902
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 3e9e43af805f4e70ce690611e64a5b5ad990f19e
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Sep 6 12:19:32 2023 +0200

    DB: Reduce risk of read/write conflicts
    
    This adds indexes to a couple often-queried columns and advises the
    database to prefer index-based lookups instead of sequential scans.
    
    Related: #902
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 8272d5be6d96836498edebb285157f9797a5e325
Author: Nils Philippsen <nils@redhat.com>
Date:   Wed Sep 6 12:44:08 2023 +0200

    Reenable concurrent session tests for pytest-xdist
    
    Add unit tests covering retried database transactions when creating
    sessions.
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>
```