### PR TITLE
Tidy up tests and CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,7 @@ client = ["httpx"]
 duffy = "duffy.cli:cli"
 
 [tool.pytest.ini_options]
-addopts = "--black --cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html --isort"
+addopts = "--cov-config .coveragerc --cov=duffy --cov-report term --cov-report xml --cov-report html"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 log_format = "%(levelname)s: %(asctime)s %(short_request_id_optional)s(%(filename)s:%(lineno)s %(message)s)"

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ skip_missing_interpreters = true
 
 [testenv]
 deps =
-  poetry
+  poetry<2
   pip
 setenv =
   COV_FAIL_UNDER = 100


### PR DESCRIPTION
commit c88459c6ad6e798a614a87e09640f95224d83faf
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Mar 10 13:30:43 2025 +0100

    Use poetry 1.x in CI
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>

commit 458b9e04c886673f2621398eb10a2bd243ed5d36
Author: Nils Philippsen <nils@redhat.com>
Date:   Mon Mar 10 12:43:31 2025 +0100

    Don’t configure pytest to run black or isort
    
    Signed-off-by: Nils Philippsen <nils@redhat.com>