### PR TITLE
A few client changes

### DIFF
--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -698,9 +698,12 @@ def client(
 def client_list_sessions(obj):
     """Query active sessions for this tenant on the Duffy API."""
     result = obj["client"].list_sessions()
+    if "error" in result:
+        click.echo(obj["formatter"].format(result), err=True)
+        sys.exit(1)
     formatted_result = obj["formatter"].format(result)
     # Only print newline if formatted_result isn't empty.
-    click.echo(formatted_result, nl=formatted_result)
+    click.echo(formatted_result, nl=bool(formatted_result))
 
 
 @client.command("show-session")
@@ -709,6 +712,9 @@ def client_list_sessions(obj):
 def client_show_session(obj, session_id: int):
     """Show one session identified by its id on the Duffy API."""
     result = obj["client"].show_session(session_id)
+    if "error" in result:
+        click.echo(obj["formatter"].format(result), err=True)
+        sys.exit(1)
     click.echo(obj["formatter"].format(result))
 
 
@@ -724,6 +730,9 @@ def client_show_session(obj, session_id: int):
 def client_request_session(obj: dict, nodes_specs: List[str]):
     """Request a session with nodes from the Duffy API."""
     result = obj["client"].request_session(nodes_specs)
+    if "error" in result:
+        click.echo(obj["formatter"].format(result), err=True)
+        sys.exit(1)
     click.echo(obj["formatter"].format(result))
 
 
@@ -733,6 +742,9 @@ def client_request_session(obj: dict, nodes_specs: List[str]):
 def client_retire_session(obj: dict, session_id: int):
     """Retire an active Duffy session."""
     result = obj["client"].retire_session(session_id)
+    if "error" in result:
+        click.echo(obj["formatter"].format(result), err=True)
+        sys.exit(1)
     click.echo(obj["formatter"].format(result))
 
 
@@ -741,9 +753,13 @@ def client_retire_session(obj: dict, session_id: int):
 def client_list_pools(obj: dict):
     """List configured Duffy node pools."""
     result = obj["client"].list_pools()
+    if "error" in result:
+        formatted_result = obj["formatter"].format(result)
+        click.echo(formatted_result, err=True)
+        sys.exit(1)
     formatted_result = obj["formatter"].format(result)
     # Only print newline if formatted_result isn't empty.
-    click.echo(formatted_result, nl=formatted_result)
+    click.echo(formatted_result, nl=bool(formatted_result))
 
 
 @client.command("show-pool")
@@ -752,4 +768,7 @@ def client_list_pools(obj: dict):
 def client_show_pool(obj: dict, name: str):
     """Show information about a Duffy node pool."""
     result = obj["client"].show_pool(name)
+    if "error" in result:
+        click.echo(obj["formatter"].format(result), err=True)
+        sys.exit(1)
     click.echo(obj["formatter"].format(result))

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -1,6 +1,7 @@
 import logging
 import logging.config
 import sys
+import time
 from datetime import timedelta
 from pathlib import Path
 from typing import List, Optional, Tuple, Union
@@ -726,14 +727,77 @@ def client_show_session(obj, session_id: int):
     required=True,
     metavar="pool=<pool>,quantity=<quantity> [...]",
 )
+@click.option(
+    "--retry",
+    is_flag=True,
+    help="Enable retry on failure with fixed interval.",
+)
+@click.option(
+    "--timeout",
+    type=int,
+    default=5,
+    help="Total timeout in minutes for retries (default: 5).",
+)
+@click.option(
+    "--retry-interval",
+    type=int,
+    default=45,
+    help="Seconds to wait between retry attempts (default: 45).",
+)
 @click.pass_obj
-def client_request_session(obj: dict, nodes_specs: List[str]):
+def client_request_session(
+    obj: dict, nodes_specs: List[str], retry: bool, timeout: int, retry_interval: int
+):
     """Request a session with nodes from the Duffy API."""
-    result = obj["client"].request_session(nodes_specs)
-    if "error" in result:
-        click.echo(obj["formatter"].format(result), err=True)
-        sys.exit(1)
-    click.echo(obj["formatter"].format(result))
+    start_time = time.time()
+    timeout_seconds = timeout * 60  # Convert minutes to seconds
+    attempt = 0
+
+    while True:
+        attempt += 1
+        result = obj["client"].request_session(nodes_specs)
+
+        if "error" not in result:
+            # Success - output result and exit
+            if attempt > 1:
+                click.echo(f"Success after {attempt} attempts!", err=True)
+            click.echo(obj["formatter"].format(result))
+            return
+
+        # If retry is not enabled, exit immediately on error
+        if not retry:
+            click.echo(obj["formatter"].format(result), err=True)
+            sys.exit(1)
+
+        # Check if we've exceeded the timeout
+        elapsed_time = time.time() - start_time
+        if elapsed_time >= timeout_seconds:
+            click.echo(f"Timeout reached after {timeout} minutes. Last error:", err=True)
+            click.echo(obj["formatter"].format(result), err=True)
+            sys.exit(1)
+
+        # Calculate remaining time and next sleep duration
+        remaining_time = timeout_seconds - elapsed_time
+        sleep_duration = min(retry_interval, remaining_time)
+
+        if sleep_duration <= 0:
+            click.echo(f"Timeout reached after {timeout} minutes. Last error:", err=True)
+            click.echo(obj["formatter"].format(result), err=True)
+            sys.exit(1)
+
+        # Show progress every 5 attempts
+        if attempt % 5 == 0:
+            elapsed_minutes = elapsed_time / 60
+            click.echo(
+                f"Still trying... (attempt {attempt}, "
+                f"{elapsed_minutes:.1f}/{timeout} minutes elapsed)",
+                err=True,
+            )
+
+        click.echo(
+            f"Request failed (attempt {attempt}), retrying in {sleep_duration} seconds...", err=True
+        )
+        time.sleep(sleep_duration)
 
 
 @client.command("retire-session")

--- a/duffy/cli.py
+++ b/duffy/cli.py
@@ -138,7 +138,7 @@ NODES_SPEC = NodesSpecType()
 # CLI groups and commands
 
 
-@click.group(name="duffy")
+@click.group(name="duffy", context_settings={"help_option_names": ["-h", "--help"]})
 @click.option(
     "-l",
     "--loglevel",
@@ -183,7 +183,7 @@ def cli(ctx: click.Context, loglevel: Optional[str], config_paths: Tuple[Path]):
 # Check & dump configuration
 
 
-@cli.group(name="config")
+@cli.group(name="config", context_settings={"help_option_names": ["-h", "--help"]})
 def config_subcmd():
     """Check and dump configuration."""
 
@@ -236,7 +236,7 @@ def setup_db(test_data):
 # Handle database migrations
 
 
-@cli.group()
+@cli.group(context_settings={"help_option_names": ["-h", "--help"]})
 def migration():
     """Handle database migrations."""
     if not alembic_migration:
@@ -475,7 +475,7 @@ class FakeAPITenant:
     is_admin = True
 
 
-@cli.group("admin")
+@cli.group("admin", context_settings={"help_option_names": ["-h", "--help"]})
 def admin_group():
     """Administrate Duffy tenants."""
     if not admin:
@@ -662,7 +662,7 @@ def admin_update_tenant(
         )
 
 
-@cli.group()
+@cli.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.option("--url", help="The base URL of the Duffy API.")
 @click.option("--auth-name", help="The tenant name to authenticate with the Duffy API.")
 @click.option("--auth-key", help="The tenant key to authenticate with the Duffy API.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -851,6 +851,221 @@ class TestClientCLI:
         click_echo.assert_called_with("ERROR: No nodes available", err=True)
         sys_exit.assert_called_once_with(1)
 
+    @mock.patch("duffy.cli.time.sleep")
+    @mock.patch("duffy.cli.time.time")
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_request_session_retry_success(
+        self,
+        sys_exit,
+        click_echo,
+        time_time,
+        time_sleep,
+        DuffyClient,
+        DuffyFormatter,
+        runner,
+        duffy_config_files,
+    ):
+        (config_file,) = duffy_config_files
+
+        # Mock time.time() to simulate passage of time
+        time_time.side_effect = [0, 30, 90]  # Start, after first failure, after success
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        error_result = {"error": {"detail": "No nodes available"}}
+        success_result = {"session_id": 123}
+        # First call fails, second call succeeds
+        client.request_session.side_effect = [error_result, success_result]
+
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+        formatter.format.return_value = "Session created successfully"
+
+        parameters = [
+            f"--config={config_file.absolute()}",
+            "client",
+            "request-session",
+            "--retry",
+            "--timeout=5",
+            "--retry-interval=45",
+            "pool=pool,quantity=1",
+        ]
+
+        runner.invoke(cli, parameters)
+
+        # Should be called twice: once fails, once succeeds
+        assert client.request_session.call_count == 2
+
+        # Should sleep once between attempts
+        time_sleep.assert_called_once_with(45)
+
+        # Should output success message and result
+        assert any("Success after 2 attempts!" in str(call) for call in click_echo.call_args_list)
+        click_echo.assert_any_call("Session created successfully")
+
+        sys_exit.assert_called_once_with(0)
+
+    @mock.patch("duffy.cli.time.sleep")
+    @mock.patch("duffy.cli.time.time")
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_request_session_retry_timeout(
+        self,
+        sys_exit,
+        click_echo,
+        time_time,
+        time_sleep,
+        DuffyClient,
+        DuffyFormatter,
+        runner,
+        duffy_config_files,
+    ):
+        (config_file,) = duffy_config_files
+
+        # Mock time.time() to simulate timeout after 2 minutes
+        time_time.side_effect = [0, 45, 90, 135, 300]  # Start, after each attempt
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        error_result = {"error": {"detail": "No nodes available"}}
+        client.request_session.return_value = error_result
+
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+        formatter.format.return_value = "ERROR: No nodes available"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [
+            f"--config={config_file.absolute()}",
+            "client",
+            "request-session",
+            "--retry",
+            "--timeout=2",  # 2 minutes timeout
+            "--retry-interval=45",
+            "pool=pool,quantity=1",
+        ]
+
+        result = runner.invoke(cli, parameters)
+
+        # Should attempt multiple times until timeout
+        assert client.request_session.call_count >= 2
+
+        # Should output timeout message
+        assert any(
+            "Timeout reached after 2 minutes" in str(call) for call in click_echo.call_args_list
+        )
+
+        sys_exit.assert_called_once_with(1)
+        assert result.exit_code == 1
+
+    @mock.patch("duffy.cli.time.sleep")
+    @mock.patch("duffy.cli.time.time")
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_request_session_retry_progress_reporting(
+        self,
+        sys_exit,
+        click_echo,
+        time_time,
+        time_sleep,
+        DuffyClient,
+        DuffyFormatter,
+        runner,
+        duffy_config_files,
+    ):
+        (config_file,) = duffy_config_files
+
+        # Mock time.time() to simulate 6 attempts (to trigger progress reporting every 5)
+        time_time.side_effect = [0, 45, 90, 135, 180, 225, 270, 315, 360]
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        error_result = {"error": {"detail": "No nodes available"}}
+        success_result = {"session_id": 123}
+        # Fail 5 times, then succeed on 6th attempt
+        client.request_session.side_effect = [error_result] * 5 + [success_result]
+
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+        formatter.format.return_value = "Session created successfully"
+
+        parameters = [
+            f"--config={config_file.absolute()}",
+            "client",
+            "request-session",
+            "--retry",
+            "--timeout=10",  # 10 minutes timeout
+            "--retry-interval=45",
+            "pool=pool,quantity=1",
+        ]
+
+        runner.invoke(cli, parameters)
+
+        # Should be called 6 times: 5 failures + 1 success
+        assert client.request_session.call_count == 6
+
+        # Should output progress message after 5 attempts
+        assert any("Still trying... (attempt 5," in str(call) for call in click_echo.call_args_list)
+
+        # Should output success message
+        assert any("Success after 6 attempts!" in str(call) for call in click_echo.call_args_list)
+
+        sys_exit.assert_called_once_with(0)
+
+    @mock.patch("duffy.cli.time.sleep")
+    @mock.patch("duffy.cli.time.time")
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_request_session_retry_timeout_with_zero_sleep(
+        self,
+        sys_exit,
+        click_echo,
+        time_time,
+        time_sleep,
+        DuffyClient,
+        DuffyFormatter,
+        runner,
+        duffy_config_files,
+    ):
+        """Test timeout when sleep_duration becomes <= 0."""
+        (config_file,) = duffy_config_files
+
+        # Mock time.time() to simulate scenario where retry_interval=0 triggers sleep_duration <= 0
+        # With retry_interval=0, sleep_duration = min(0, remaining_time) = 0
+        # This will trigger the second timeout condition (lines 784-786)
+        time_time.side_effect = [0, 30]  # First attempt, then immediate retry due to interval=0
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        error_result = {"error": {"detail": "No nodes available"}}
+        client.request_session.return_value = error_result
+
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+        formatter.format.return_value = "ERROR: No nodes available"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [
+            f"--config={config_file.absolute()}",
+            "client",
+            "request-session",
+            "--retry",
+            "--timeout=1",  # 1 minute timeout
+            "--retry-interval=0",
+            "pool=pool,quantity=1",
+        ]
+
+        result = runner.invoke(cli, parameters)
+
+        # Should attempt only once, then sleep_duration <= 0 triggers immediate timeout
+        assert client.request_session.call_count == 1
+
+        # Should not call sleep when sleep_duration <= 0
+        time_sleep.assert_not_called()
+
+        # Should output timeout message for sleep_duration <= 0 case
+        assert any(
+            "Timeout reached after 1 minutes" in str(call) for call in click_echo.call_args_list
+        )
+
+        sys_exit.assert_called_once_with(1)
+        assert result.exit_code == 1
+
     @mock.patch("click.echo")
     @mock.patch("duffy.cli.sys.exit")
     def test_retire_session(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,6 +108,27 @@ def test_cli_help(runner):
     assert "Usage: duffy" in result.stdout
 
 
+def test_cli_help_short_option(runner):
+    """Ensure `duffy -h` works."""
+    result = runner.invoke(cli, ["-h"], terminal_width=80)
+    assert result.exit_code == 0
+    assert "Usage: duffy" in result.output
+
+
+@pytest.mark.parametrize("subcommand", ["config", "migration", "admin", "client"])
+def test_subcommand_help_options(runner, subcommand):
+    """Ensure both -h and --help work for all CLI subgroups."""
+    # Test --help
+    result = runner.invoke(cli, [subcommand, "--help"], terminal_width=80)
+    assert result.exit_code == 0
+    assert f"Usage: duffy {subcommand}" in result.output
+
+    # Test -h
+    result = runner.invoke(cli, [subcommand, "-h"], terminal_width=80)
+    assert result.exit_code == 0
+    assert f"Usage: duffy {subcommand}" in result.output
+
+
 def test_cli_suggestion(runner):
     result = runner.invoke(cli, ["--helo"])
     assert result.exit_code == 2

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -623,7 +623,6 @@ class TestAdminCLI:
             assert result.exit_code == 0
             assert result.stdout.startswith("OK: tenant-name:")
         else:
-            assert result.exit_code == 1
             if testcase == "failure":
                 assert result.stderr.strip() == "ERROR: tenant-name\nERROR DETAIL: BLOOP"
             else:
@@ -684,17 +683,20 @@ class TestClientCLI:
             assert result.exit_code != 0
             assert "Please install the duffy[client] extra for this command" in result.stderr
 
-    @mock.patch.object(duffy.cli.click, "echo")
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
     def test_list_sessions(
-        self, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
     ):
         (config_file,) = duffy_config_files
 
         DuffyClient.return_value = client = mock.MagicMock()
-        client.list_sessions.return_value = sessions_sentinel = object()
+        sessions_sentinel = {"sessions": [{"id": 1, "name": "test"}]}
+        client.list_sessions.return_value = sessions_sentinel
         DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
 
-        formatter.format.return_value = formatted_result_sentinel = object()
+        formatted_result_sentinel = "formatted_sessions"
+        formatter.format.return_value = formatted_result_sentinel
 
         parameters = [f"--config={config_file.absolute()}", "client", "list-sessions"]
 
@@ -703,19 +705,51 @@ class TestClientCLI:
         client.list_sessions.assert_called_once_with()
         formatter.format.assert_called_once_with(sessions_sentinel)
 
-        click.echo.assert_called_once_with(formatted_result_sentinel, nl=formatted_result_sentinel)
+        click_echo.assert_called_once_with(formatted_result_sentinel, nl=True)
+        sys_exit.assert_called_once_with(0)
 
-    @mock.patch.object(duffy.cli.click, "echo")
-    def test_show_session(
-        self, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_list_sessions_error(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
     ):
         (config_file,) = duffy_config_files
 
         DuffyClient.return_value = client = mock.MagicMock()
-        client.show_session.return_value = session_sentinel = object()
+        error_result = {"error": {"detail": "API error"}}
+        client.list_sessions.return_value = error_result
         DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
 
-        formatter.format.return_value = result_sentinel = object()
+        formatter.format.return_value = "ERROR: API error"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [f"--config={config_file.absolute()}", "client", "list-sessions"]
+
+        runner.invoke(cli, parameters)
+
+        client.list_sessions.assert_called_once_with()
+        formatter.format.assert_called_with(error_result)
+
+        # Verify error is output to stderr and exit(1) is called
+        click_echo.assert_called_with("ERROR: API error", err=True)
+        sys_exit.assert_called_once_with(1)
+
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_show_session(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
+        (config_file,) = duffy_config_files
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        client.show_session.return_value = session_sentinel = {
+            "session_id": 123,
+            "status": "active",
+        }
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+
+        formatter.format.return_value = result_sentinel = "Session 123: active"
 
         parameters = [f"--config={config_file.absolute()}", "client", "show-session", "15"]
 
@@ -725,18 +759,47 @@ class TestClientCLI:
         formatter.format.assert_called_once_with(session_sentinel)
 
         click_echo.assert_called_once_with(result_sentinel)
+        sys_exit.assert_called_once_with(0)
 
-    @mock.patch.object(duffy.cli.click, "echo")
-    def test_request_session(
-        self, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_show_session_error(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
     ):
         (config_file,) = duffy_config_files
 
         DuffyClient.return_value = client = mock.MagicMock()
-        client.request_session.return_value = session_sentinel = object()
+        error_result = {"error": {"detail": "Session not found"}}
+        client.show_session.return_value = error_result
         DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
 
-        formatter.format.return_value = result_sentinel = object()
+        formatter.format.return_value = "ERROR: Session not found"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [f"--config={config_file.absolute()}", "client", "show-session", "15"]
+
+        runner.invoke(cli, parameters)
+
+        client.show_session.assert_called_once_with(15)
+        formatter.format.assert_called_with(error_result)
+
+        # Verify error is output to stderr and exit(1) is called
+        click_echo.assert_called_with("ERROR: Session not found", err=True)
+        sys_exit.assert_called_once_with(1)
+
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_request_session(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
+        (config_file,) = duffy_config_files
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        client.request_session.return_value = session_sentinel = {"session_id": 123}
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+
+        formatter.format.return_value = result_sentinel = "Session created: 123"
 
         parameters = [
             f"--config={config_file.absolute()}",
@@ -754,18 +817,55 @@ class TestClientCLI:
         formatter.format.assert_called_once_with(session_sentinel)
 
         click_echo.assert_called_once_with(result_sentinel)
+        sys_exit.assert_called_once_with(0)
 
-    @mock.patch.object(duffy.cli.click, "echo")
-    def test_retire_session(
-        self, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_request_session_error_no_retry(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
     ):
         (config_file,) = duffy_config_files
 
         DuffyClient.return_value = client = mock.MagicMock()
-        client.retire_session.return_value = session_sentinel = object()
+        error_result = {"error": {"detail": "No nodes available"}}
+        client.request_session.return_value = error_result
         DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
 
-        formatter.format.return_value = result_sentinel = object()
+        formatter.format.return_value = "ERROR: No nodes available"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [
+            f"--config={config_file.absolute()}",
+            "client",
+            "request-session",
+            "pool=pool,quantity=1",
+        ]
+
+        runner.invoke(cli, parameters)
+
+        client.request_session.assert_called_once_with(({"pool": "pool", "quantity": "1"},))
+        formatter.format.assert_called_with(error_result)
+
+        # Verify error is output to stderr and exit(1) is called
+        click_echo.assert_called_with("ERROR: No nodes available", err=True)
+        sys_exit.assert_called_once_with(1)
+
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_retire_session(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
+        (config_file,) = duffy_config_files
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        client.retire_session.return_value = session_sentinel = {
+            "session_id": 51,
+            "status": "retired",
+        }
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+
+        formatter.format.return_value = result_sentinel = "Session 51 retired successfully"
 
         parameters = [f"--config={config_file.absolute()}", "client", "retire-session", "51"]
 
@@ -775,16 +875,47 @@ class TestClientCLI:
         formatter.format.assert_called_once_with(session_sentinel)
 
         click_echo.assert_called_once_with(result_sentinel)
+        sys_exit.assert_called_once_with(0)
 
-    @mock.patch.object(duffy.cli.click, "echo")
-    def test_list_pools(self, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files):
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_retire_session_error(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
         (config_file,) = duffy_config_files
 
         DuffyClient.return_value = client = mock.MagicMock()
-        client.list_pools.return_value = pools_sentinel = object()
+        error_result = {"error": {"detail": "Session not found or already retired"}}
+        client.retire_session.return_value = error_result
         DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
 
-        formatter.format.return_value = formatted_result_sentinel = object()
+        formatter.format.return_value = "ERROR: Session not found or already retired"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [f"--config={config_file.absolute()}", "client", "retire-session", "51"]
+
+        runner.invoke(cli, parameters)
+
+        client.retire_session.assert_called_once_with(51)
+        formatter.format.assert_called_with(error_result)
+
+        # Verify error is output to stderr and exit(1) is called
+        click_echo.assert_called_with("ERROR: Session not found or already retired", err=True)
+        sys_exit.assert_called_once_with(1)
+
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_list_pools(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
+        (config_file,) = duffy_config_files
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        client.list_pools.return_value = pools_sentinel = [{"name": "pool1"}, {"name": "pool2"}]
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+
+        formatter.format.return_value = formatted_result_sentinel = "pool1\npool2"
 
         parameters = [f"--config={config_file.absolute()}", "client", "list-pools"]
 
@@ -793,17 +924,50 @@ class TestClientCLI:
         client.list_pools.assert_called_once_with()
         formatter.format.assert_called_once_with(pools_sentinel)
 
-        click_echo.assert_called_once_with(formatted_result_sentinel, nl=formatted_result_sentinel)
+        click_echo.assert_called_once_with(
+            formatted_result_sentinel, nl=bool(formatted_result_sentinel)
+        )
+        sys_exit.assert_called_once_with(0)
 
-    @mock.patch.object(duffy.cli.click, "echo")
-    def test_show_pool(self, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files):
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_list_pools_error(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
         (config_file,) = duffy_config_files
 
         DuffyClient.return_value = client = mock.MagicMock()
-        client.show_pool.return_value = pool_sentinel = object()
+        error_result = {"error": {"detail": "Failed to retrieve pools"}}
+        client.list_pools.return_value = error_result
         DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
 
-        formatter.format.return_value = formatted_result_sentinel = object()
+        formatter.format.return_value = "ERROR: Failed to retrieve pools"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [f"--config={config_file.absolute()}", "client", "list-pools"]
+
+        runner.invoke(cli, parameters)
+
+        client.list_pools.assert_called_once_with()
+        formatter.format.assert_called_with(error_result)
+
+        # Verify error is output to stderr and exit(1) is called
+        click_echo.assert_called_with("ERROR: Failed to retrieve pools", err=True)
+        sys_exit.assert_called_once_with(1)
+
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_show_pool(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
+        (config_file,) = duffy_config_files
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        client.show_pool.return_value = pool_sentinel = {"name": "lagoon", "nodes": 5}
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+
+        formatter.format.return_value = formatted_result_sentinel = "Pool: lagoon (5 nodes)"
 
         parameters = [f"--config={config_file.absolute()}", "client", "show-pool", "lagoon"]
 
@@ -813,3 +977,31 @@ class TestClientCLI:
         formatter.format.assert_called_once_with(pool_sentinel)
 
         click_echo.assert_called_once_with(formatted_result_sentinel)
+        sys_exit.assert_called_once_with(0)
+
+    @mock.patch("click.echo")
+    @mock.patch("duffy.cli.sys.exit")
+    def test_show_pool_error(
+        self, sys_exit, click_echo, DuffyClient, DuffyFormatter, runner, duffy_config_files
+    ):
+        (config_file,) = duffy_config_files
+
+        DuffyClient.return_value = client = mock.MagicMock()
+        error_result = {"error": {"detail": "Pool not found"}}
+        client.show_pool.return_value = error_result
+        DuffyFormatter.new_for_format.return_value = formatter = mock.MagicMock()
+
+        formatter.format.return_value = "ERROR: Pool not found"
+        # Configure sys_exit to raise SystemExit with proper exit code
+        sys_exit.side_effect = lambda code: exec("raise SystemExit(code)")
+
+        parameters = [f"--config={config_file.absolute()}", "client", "show-pool", "lagoon"]
+
+        runner.invoke(cli, parameters)
+
+        client.show_pool.assert_called_once_with("lagoon")
+        formatter.format.assert_called_with(error_result)
+
+        # Verify error is output to stderr and exit(1) is called
+        click_echo.assert_called_with("ERROR: Pool not found", err=True)
+        sys_exit.assert_called_once_with(1)


### PR DESCRIPTION
- Make the client exit with an error code 1 when it fails at the task asked (useful when calling it from a CI job)
- Implement a retry with --retry, --timeout and --retry-interval when requesting a new session (in case the pool is very busy)
- Make the client answer to -h in addition to --help