### PR TITLE
CI: Pin Fedora version for Python 3.8

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,9 +21,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        tox-env: ["py38", "py39", "py310", "py311", "py312", "py313"]
+        include:
+          - toxenv: py38
+            fedver: f41
+          - toxenv: py39
+            fedver: latest
+          - toxenv: py310
+            fedver: latest
+          - toxenv: py311
+            fedver: latest
+          - toxenv: py312
+            fedver: latest
+          - toxenv: py313
+            fedver: latest
     runs-on: ubuntu-latest
-    container: fedorapython/fedora-python-tox:latest
+    container: "fedorapython/fedora-python-tox:${{ matrix.fedver }}"
     steps:
       - uses: actions/checkout@v6
 
@@ -38,4 +50,4 @@ jobs:
 
       - name: Execute tox
         run: |
-          su testrunner -c 'tox -e ${{ matrix.tox-env }}'
+          su testrunner -c 'tox -e ${{ matrix.toxenv }}'


### PR DESCRIPTION
The Fedora 42 image dropped this Python version, so use an older one.